### PR TITLE
Add Vgen input validation

### DIFF
--- a/classes/ScinthDef.sc
+++ b/classes/ScinthDef.sc
@@ -14,9 +14,13 @@ ScinthDef {
 		VGen.buildScinthDef = this;
 		func = vGenGraphFunc;
 		func.valueArray(this.prBuildControls);
-		VGen.buildScinthDef = nil;
-		children.do({ |vgen, index| this.prFitDimensions(vgen) });
-		^this;
+
+		protect {
+			this.checkInputs;
+			children.do({ |vgen, index| this.prFitDimensions(vgen) });
+		} {
+			VGen.buildScinthDef = nil;
+		}
 	}
 
 	// All controls right now are at the fragment rate, so no grouping or sorting is needed, and we only
@@ -139,6 +143,29 @@ ScinthDef {
 	addVGen { |vgen|
 		vgen.scinthIndex = children.size;
 		children = children.add(vgen);
+	}
+
+	checkInputs {
+		var firstErr;
+		children.do { | vgen |
+			var err;
+			if((err = vgen.checkInputs).notNil) {
+				err = vgen.class.asString + err;
+				err.postln;
+				vgen.dumpArgs;
+
+				if(firstErr.isNil) {
+					firstErr = err;
+				};
+			};
+		};
+
+		if(firstErr.notNil) {
+			"ScinthDef % build failed".format(this.name).postln;
+			Error(firstErr).throw;
+		};
+
+		^true;
 	}
 
 }

--- a/classes/VGen.sc
+++ b/classes/VGen.sc
@@ -204,6 +204,10 @@ VOutputProxy : VGen {
 	// .dot, .cross, etc.
 }
 
++ UGen {
+	isValidVGenInput { ^false }
+}
+
 + Array {
 	asVGenInput { |for|
 		^this.collect(_.asVGenInput(for));

--- a/classes/VGen.sc
+++ b/classes/VGen.sc
@@ -87,6 +87,15 @@ VGen : AbstractFunction {
 
 	asVGenInput { ^this }
 	isValidVGenInput { ^true }
+	checkInputs { ^this.checkValidInputs; }
+	checkValidInputs {
+		inputs.do { | input, ind |
+			if(input.isValidVGenInput.not) {
+				^"arg: '%' has bad input: %".format(this.argNameForInputAt(ind), input);
+			};
+		};
+		^nil;
+	}
 	isVGen { ^true }
 	name { ^this.class.asString }
 	numOutputs { this.outputDimensions.length }
@@ -102,6 +111,31 @@ VGen : AbstractFunction {
 
 	isSamplerVGen {
 		^false;
+	}
+
+	dumpArgs {
+		" ARGS: ".postln;
+		inputs.do { | input, ind |
+			"     % : % %".format(this.argNameForInputAt(ind) ? ind.asString, input, input.class).postln;
+		};
+	}
+
+	argNamesInputOffset { ^1; }
+
+	argNameForInputAt { | ind |
+		var method = this.class.class.findMethod(this.methodSelectorForRate);
+
+		if(method.isNil || method.argNames.isNil) {
+			^nil;
+		};
+
+		^method.argNames.at(ind + this.argNamesInputOffset);
+	}
+
+	methodSelectorForRate {
+		^switch(rate)
+		{\fragment} { \fg }
+		{nil}
 	}
 }
 

--- a/tests/TestScinthDef.sc
+++ b/tests/TestScinthDef.sc
@@ -172,4 +172,36 @@ TestScinthDef : UnitTest {
 		this.sanityCheckBuild(def);
 		this.sanityCheckYAML(def, def.asYAML);
 	}
+
+	test_vgenInputValid_nilIsInvalid {
+		var expected = "BWOut arg: 'v' has bad input: nil";
+		var err;
+
+		try {
+			ScinthDef(\vgen_nilIsInvalid, {
+				BWOut.fg(nil);
+			});
+		} { | e |
+			err = e;
+		};
+
+		this.assert(err != nil, "VGen threw an error");
+		this.assert(expected == err.what, "VGen threw the expected error");
+	}
+
+	test_vgenInputValid_ugenIsInvalid {
+		var expected = "BWOut arg: 'v' has bad input: a SinOsc";
+		var err;
+
+		try {
+			ScinthDef(\vgen_nilIsInvalid, {
+				BWOut.fg(SinOsc.ar());
+			});
+		} { | e |
+			err = e;
+		};
+
+		this.assert(err != nil, "VGen threw an error");
+		this.assert(expected == err.what, "VGen threw the expected error");
+	}
 }


### PR DESCRIPTION
## Purpose and motivation

This aims to address #94.

Previously, inputs to UGens weren't being checked for validity before building the ScinthDef.
This led to errors that weren't easy to track down.

## Types of changes
- Enhancement

## Implementation

This PR implements similar mechanisms as used in UGen and SynthDef to provide earlier errors and more informative messages.

Additionally, it marks UGen as invalid input for a VGen (UGen validity was inherited through AbstractFunction).

- [x] This PR is ready for review
- [x] Adds unit tests
- [x] Tests passing