### PR TITLE
Fix some server boot issues

### DIFF
--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -111,6 +111,8 @@ ScinServer {
 			options = ScinServerOptions.new;
 		});
 
+		addr = NetAddr.new("127.0.0.1", options.portNumber);
+
 		scinBinaryPath = options.quarkPath +/+ "bin";
 		Platform.case(
 			\osx, {
@@ -123,6 +125,7 @@ ScinServer {
 			\linux, { scinBinaryPath = scinBinaryPath +/+ "scinsynth-x86_64.AppImage" },
 			\windows, { Error.new("Windows not (yet) supported!").throw }
 		);
+
 		statusPoller = ScinServerStatusPoller.new(this);
 	}
 
@@ -146,7 +149,6 @@ ScinServer {
 		if (ScinServer.default.isNil, {
 			ScinServer.default = this;
 		});
-		addr = NetAddr.new("127.0.0.1", options.portNumber);
 		^this;
 	}
 

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -142,6 +142,7 @@ ScinServer {
 		scinPid = commandLine.unixCmd({ |exitCode, exitPid|
 			"*** got scinsynth exit code %".format(exitCode).postln;
 			if (exitCode != 0, {
+				statusPoller.serverBooting = false;
 				options.onServerError.value(exitCode);
 			});
 		});


### PR DESCRIPTION
## Purpose and motivation

Previously, ScinServer created the ScinServerStatusPoller during init, and created its NetAddr while booting. This meant that unless you booted immediately, the status poller would error, trying to poll `nil`.

Additionally, if the server failed to boot, the status poller would remain in a state of booting.
This meant that it was impossible to boot after an error.

## Implementation

This PR moves the creation of the NetAddr into the init method, ensuring it is available from the start.

Additionally, when the server fails to boot, the status poller is now notified that serverBooting is false.

With this PR, users can use the following style (as with SC audio server):
```supercollider
v = ScinServer();
v.options.width = 400;
v.options.height = 300;

v.boot;
```

And if it fails, options can be modified and boot called again:

```supercollider
v = ScinServer();
v.boot; // assume failed: no vulkan devices available
v.options.swiftshader = true;
v.boot; // ok
```

## Types of changes
* Bug fix
* Enhancement

## Checklist
- [x] This PR is ready for review
