### PR TITLE
Adds sclang-based server installation script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # The authoritative version of Scintillator is always in the Scintillator.quark file in the root directory of the
 # project. This version is manually kept in sync and should be updated to match. Both C++ and sclang Scintillator code
 # is developed in parallel, and is designed to be released together.
-project(Scintillator VERSION 0.0.4 LANGUAGES C CXX)
+project(Scintillator VERSION 0.0.5 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED)
 

--- a/HelpSource/Classes/ScinServerInstaller.schelp
+++ b/HelpSource/Classes/ScinServerInstaller.schelp
@@ -1,0 +1,38 @@
+TITLE:: ScinServerInstaller
+summary:: An automatic installation script for the Scintillator server.
+categories:: Quarks>Scintillator>Scintillator Server
+related:: Classes/ScinServer
+
+DESCRIPTION::
+Scintillator is distributed in two parts, the Quark code and the server binary. The ScinServerInstaller class is distributed with the Scintillator quark and can be used to update or install the server binary.
+
+CLASSMETHODS::
+
+METHOD:: setup
+
+Checks if the server binary is installed and if it is the correct version. If not, it will download, validate, and install the correct server binary.
+
+ARGUMENT:: cleanup
+A boolean, default true. If true, the setup script will delete the downloaded files and any old server binaries that might be still around. If false, it will rename any existing server binaries with their version suffix, and keep the downloaded files in place.
+
+ARGUMENT:: validate
+A boolean, default true. If true, the script will also compute a hash of the downloaded file and compare it to a precomputed value. If false it will skip validation.
+
+METHOD:: abort
+
+Call to cancel the installation script while it's in progress.
+
+EXAMPLES::
+
+code::
+// Script to update Scintillator to latest version.
+(
+Quarks.update("Scintillator");
+)
+
+// !! Recompile Class Libary Here !!
+
+(
+ScinServerInstaller.setup;
+)
+::

--- a/HelpSource/Guides/Scintillator-User-Guide.schelp
+++ b/HelpSource/Guides/Scintillator-User-Guide.schelp
@@ -1,21 +1,19 @@
 title:: Scintillator User Guide
-summary:: User manual for the Scintillator visual synthesizer.
+summary:: User manual for the Scintillator video synthesizer.
 categories:: Quarks>Scintillator>Guides
 related:: Classes/ScinthDef, Classes/ScinServer
 
-In keeping with the high-energy physics themes of SuperCollider, a emphasis::scintillator:: is any material that produces light when struck by radition. Scintillator is intended to be an accompanying visual synthesizer designed to be intuitive to users already familiar with SuperCollider idioms. Distributed as a Quark plus a synthesizer binary, Scintillator follows the client/server archiecture established by SuperCollider, accepts link::Classes/ScinthDef::s in a similar manner to SuperCollider link::Classes/SynthDef::s, provides facilities to invoke and control link::Classes/Scinth:: instances similar to link::Classes/Synth::, and so on. For a detailed list of classes with analogous SuperCollider classes see link::Guides/Scintillator-Parallel-Classes::.
+section::Overview
 
-section::Project Status (April 2020)
+Scintillator is a video synthesis extension for SuperCollider. It is distributed as a Quark, but requires an additional download and installation step to get the synthesizer program.
 
-Scintillator is an open-source (GPLv3) project developed and maintained by Luke Nihlen. It is in early pre-alpha stage and the purpose of these first few releases is to gather feedback and identify any outstanding major bugs that might need to be resolved before considering a beta or even production-quality release. Central features are under active development, and the classes and their methods may change from point release to point release without notice. As such Scintillator is ready for review but building a larger composition or planning a performance on it may not be advisable.
+Scintillator is designed to be intuitive to users already familiar with SuperCollider idioms. It follows the client/server archiecture established by SuperCollider, accepts link::Classes/ScinthDef::s in a similar manner to SuperCollider link::Classes/SynthDef::s, provides facilities to invoke and control link::Classes/Scinth:: instances similar to link::Classes/Synth::, and so on. For a detailed list of classes with analogous SuperCollider classes see link::Guides/Scintillator-Parallel-Classes::.
 
-All that said, it is my sincere hope you find Scintillator useful and interesting, and I'm keen to hear your feedback. Drop by the link::https://github.com/ScintillatorSynth/Scintillator##GitHub project page::, if you encounter any bugs or have any feature requests please feel free to file them there, or drop me an email at code::scintillator.synth@gmail.com::.
+section::Installation Instructions
 
-section::Installation
+subsection::1. Install Scintillator Quark
 
-subsection::Quark Installation
-
-Scintillator is distributed in two pieces and both are required in order for it to run. The first piece contains the SuperCollider classes and support, and is distributed as a Quark. Installation should be as simple as executing the following code:
+Run the following code:
 
 code::
 (
@@ -24,6 +22,14 @@ Quarks.install("Scintillator");
 ::
 
 Or you can use the Quarks GUI to pick out Scintillator and install it. See link::Guides/UsingQuarks:: for more information.
+
+subsection::2. Recompile Class Library
+
+After any Quark installation you need to recompile the SuperCollider class library. In the IDE menu select Langage -> Recompile Class Library.
+
+subsection::3. Download Server Binary
+
+Use a web browser and go to the the link::https://github.com/ScintillatorSynth/Scintillator/releases##GitHub Releases Page:: at https://github.com/ScintillatorSynth/Scintillator/releases. Download the latest release
 
 subsection::Server Binary Installation
 
@@ -216,5 +222,7 @@ It can be instructive to think about why the code::phase:: argument to VSaw is n
 
 subsection::Next Steps
 
-It's definitely worth perusing the link::Guides/VGens-Overview:: to get a better understanding of currently supported VGens, to expand your creative options. There are a lot of additional features planned for Scintillator, which will likely be documented in separate, independent guides. Lastly, join the conversation! Post your feedback and questions on the link::https://github.com/ScintillatorSynth/Scintillator##GitHub page::, find me on the SuperCollider slack channel, or drop me a line over email.
+Scintillator is still in active development. The link::https://scintillatorsynth.org/blog/##Development Blog:: typically has the most up-to-date information.
+
+It's definitely worth perusing the link::Guides/VGens-Overview:: to get a better understanding of currently supported VGens. There are a lot of additional features planned for Scintillator, which will likely be documented in separate, independent guides. Lastly, join the conversation! Post your feedback and questions on the link::https://github.com/ScintillatorSynth/Scintillator##GitHub page::, find me on the SuperCollider slack channel, or drop me a line over email.
 

--- a/HelpSource/Guides/Scintillator-User-Guide.schelp
+++ b/HelpSource/Guides/Scintillator-User-Guide.schelp
@@ -27,31 +27,23 @@ subsection::2. Recompile Class Library
 
 After any Quark installation you need to recompile the SuperCollider class library. In the IDE menu select Langage -> Recompile Class Library.
 
-subsection::3. Download Server Binary
+subsection::3. Option A - Automatic Server Install
 
-Use a web browser and go to the the link::https://github.com/ScintillatorSynth/Scintillator/releases##GitHub Releases Page:: at https://github.com/ScintillatorSynth/Scintillator/releases. Download the latest release
-
-subsection::Server Binary Installation
-
-The second half of the Scintillator distribution consists of the code::scinsynth:: binary, which is the C++-based visual synthesis server. Official releases of the Scintillator Quark will always have an associated server binary, which can be obtained from the link::https://github.com/ScintillatorSynth/Scintillator/releases##GitHub Releases Page::. Each platform names the server binary file slightly differently, but generally once the binary is downloaded you need to move it into the code::/bin:: subdirectory inside of the Scintillator Quark directory. One way to quickly find the quark directory is to use the link::Classes/ScinServerOptions:: class, which computes the location by querying the Quarks system:
+The link::Classes/ScinServerInstaller:: class is an install script that can download the synth binary and automatically install it. To use it run the following code:
 
 code::
-// Prints the path of the quark to the console.
 (
-~o = ScinServerOptions.new;
-~o.quarkPath.postln;
+ScinServerInstaller.setup;
 )
 ::
 
-The binary is named and installed a bit differently on each platform:
-table::
-## strong::platform:: || strong::binary name:: || strong::post-install step::
-## MacOS || code::scinsynth.app.zip:: || Need to extract the zip file
-## Linux || code::scinsynth-x86_64.AppImage:: || Need to mark the file as executable
-## Windows || emphasis::not yet supported:: || Windows support planned for production release
-::
+The installer will report status to the log. Please report any issues with using it to the developers.
 
-section::Quick Startup
+subsection::3. Option B - Manual Server Install
+
+Use a web browser and go to the the link::https://github.com/ScintillatorSynth/Scintillator/releases##GitHub Releases Page:: at https://github.com/ScintillatorSynth/Scintillator/releases. Follow the instructions on the Releases page to finish the install process.
+
+section::Tutorial
 
 This section can serve to validate your Scintillator installation, as well as to establish some of the basic concepts and get some pixels lighting up on the screen. The first step will be to get an instance of the video server running, which will require installing the correct server binary for your platform of choice. To validate that the server binary is installed correctly we'll start the server, define a link::Classes/ScinthDef::, and render the definition with a link::Classes/Scinth::.
 

--- a/Scintillator.quark
+++ b/Scintillator.quark
@@ -2,7 +2,7 @@
 	name: "Scintillator",
 	summary: "A Vulkan-based video synthesizer for SuperCollider",
 	author: "Luke Nihlen",
-	version: "0.0.4",
+	version: "0.0.5",
 	schelp: "Guides/Scintillator-User-Guide",
 	license: "GPL",
 	copyright: "Luke Nihlen 2020",

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -126,6 +126,11 @@ ScinServer {
 			\windows, { Error.new("Windows not (yet) supported!").throw }
 		);
 
+		if (File.exists(scinBinaryPath).not, {
+			Error.new("Unable to find Scintillator Server binary. Please run ScinServerInstaller.setup first.").throw;
+			^nil;
+		});
+
 		statusPoller = ScinServerStatusPoller.new(this);
 	}
 
@@ -140,10 +145,10 @@ ScinServer {
 		commandLine = scinBinaryPath + options.asOptionsString();
 
 		scinPid = commandLine.unixCmd({ |exitCode, exitPid|
-			"*** got scinsynth exit code %".format(exitCode).postln;
-			if (exitCode != 0, {
-				statusPoller.serverBooting = false;
-				options.onServerError.value(exitCode);
+			if (exitCode == 0, {
+				"*** scinsynth exited normally.".postln;
+			}, {
+				"*** scinsynth fatal error, code: %".format(exitCode).postln;
 			});
 		});
 

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -1,0 +1,78 @@
+ScinServerInstaller {
+	const releasesURL = "https://github.com/ScintillatorSynth/Scintillator/releases/download/";
+
+	*install { |quarkPath|
+		var version, binPath, downloadName, url, download;
+
+		// Extract Scintillator version from Quark metadata.
+		Quarks.installed.do({ |quark, index|
+			if (quark.name == "Scintillator", {
+				if (quarkPath.isNil, {
+					quarkPath = quark.localPath;
+				});
+				version = quark.version;
+			});
+		});
+
+		binPath = quarkPath +/+ "bin";
+
+		// Build URL with platform-dependent download filename.
+		Platform.case(
+			\osx, {
+				downloadName = "scinsynth.app.zip";
+			},
+			\linux, {
+				downloadName = "scinsynth-x86_64.AppImage";
+			},
+			\windows, { Error.new("Windows not (yet) supported!").throw }
+		);
+
+		File.delete(binPath +/+ downloadName);
+
+		url = releasesURL ++ version ++ "/" ++ downloadName;
+		"Scintillator Server Installer downloading % server binary from %, saving to %".format(
+			thisProcess.platform.name, url, binPath).postln;
+
+		download = Download.new(url, binPath +/+ "foo", {
+			ScinServerInstaller.prOnDownload(binPath)
+		}, {
+			ScinServerInstaller.prOnDownloadError;
+		}, { |r, t|
+			"  downloaded % / % bytes".format(r, t).postln;
+		});
+	}
+
+	*prOnDownload { |binPath|
+		"Scintillator binary download complete. Finalizing..".postln;
+
+		Platform.case(
+			\osx, {
+				File.deleteAll(binPath +/+ "scinsynth.app");
+			},
+			\linux, {
+				"chmod u+x %/scinsynth-x86_64.AppImage".format(binPath).unixCmd({ |exit, pid|
+					if (exit == 0, {
+						ScinServerInstaller.prOnComplete;
+					}, {
+						ScinServerInstaller.prOnError;
+					});
+				}, false);
+			},
+			\windows, { Error.new("Windows not (yet) supported!").throw }
+		);
+	}
+
+	*prOnDownloadError {
+		"*** error downloading Scintillator binary!".postln;
+		"  Please double-check your Internet configuration. Failing that, try the manual "
+		"install path detailed in the Scintillator User Guide in the help.".postln;
+	}
+
+	*prOnComplete {
+		"*** Scintillator server download complete!".postln;
+	}
+
+	*prOnError {
+		"*** error finalizing Scintillator server setup.".postln;
+	}
+}

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -143,10 +143,8 @@ ScinServerInstaller {
 						c.wait;
 						if (result, {
 							if (validate, {
-								"download complete, validating.".postln;
 								state = \checkIfHashExists;
 							}, {
-								"download complete, extracting.".postln;
 								state = \extractBinary;
 							});
 						}, {
@@ -183,7 +181,6 @@ ScinServerInstaller {
 							c.test = true;
 							c.signal;
 						}, {
-							".".post;
 						});
 
 						c.wait;
@@ -224,11 +221,15 @@ ScinServerInstaller {
 						}, {
 							Platform.case(
 								\osx, {
-									var result = "unzip \"%\" -d \"%\"".format(downloadPath, quarkBinPath).unixCmdGetStdOut;
-									result.postln;
+									"unzip \"%\" -d \"%\"".format(downloadPath, quarkBinPath).unixCmdGetStdOut.postln;
 									state = \checkIfBinaryExists;
 								},
 								\linux, {
+									"gzip -d \"%\"".format(downloadPath).unixCmdGetStdOut.postln;
+									"mv \"%\" \"%\"".format(downloadPath[0..downloadPath.size - 4],
+										binaryPath).unixCmdGetStdOut.postln;
+									"chmod u+x \"%\"".format(binaryPath).unixCmdGetStdOut.postln;
+									state = \checkIfBinaryExists;
 								},
 								\windows, {
 									continue = false;

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -1,6 +1,7 @@
 ScinServerInstaller {
 	const releasesURL = "https://scintillator-synth-coverage.s3-us-west-1.amazonaws.com/releases/";
 	classvar routine;
+	classvar continue;
 
 	*setup { |cleanup=true, validate=true|
 		if (routine.notNil, {
@@ -11,7 +12,7 @@ ScinServerInstaller {
 			var version, quarkBinPath, binaryPath, downloadURL, downloadPath, runtime;
 			var oldVersion, oldBinPath;
 			var state = \init;
-			var continue = true;
+			continue = true;
 
 			while ({ continue }, {
 				switch (state,
@@ -75,6 +76,15 @@ ScinServerInstaller {
 							var scinVersion = split[2];
 							if (scinVersion == version, {
 								"scin installer detects version match % between Quark and binary.".format(version).postln;
+								if (cleanup, {
+									if (downloadPath.notNil, {
+										File.delete(downloadPath);
+										File.delete(downloadPath ++ ".sha256");
+									});
+									if (oldBinPath.notNil, {
+										File.deleteAll(oldBinPath);
+									});
+								});
 								"*** You're all set, happy Scintillating!".postln;
 								continue = false;
 							}, {
@@ -233,7 +243,7 @@ ScinServerInstaller {
 							"*** unable to determine version of old binary, using \"unknown\"".postln;
 							oldVersion = ".unknown";
 						});
-						oldBinPath = binaryPath ++ oldVersion ++ ".bak";
+						oldBinPath = binaryPath ++ "." ++ oldVersion ++ ".bak";
 						"mv \"%\" \"%\"".format(binaryPath, oldBinPath).unixCmdGetStdOut;
 						state = \extractBinary;
 					},
@@ -244,6 +254,7 @@ ScinServerInstaller {
 
 	*abort {
 		"*** aborting setup.".postln;
+		continue = false;
 		if (routine.notNil, {
 			routine.stop;
 		});


### PR DESCRIPTION
## Purpose and motivation

This PR addresses several of the issues raised in #88, which was based on early user feedback around the documentation of the installation process for the Scintillator server binary.

## Implementation

Adds a new class, `ScinServerInstaller`, which has a `setup` method which can download the version-matching server binary from S3, validate it against the provided hash, and set it up for execution.

Also some improvements to server error messaging on the client side.

## Types of changes

* Enhancement
* Documentation

## Status

- [ ] This PR is ready for review
