### PR TITLE
Initialise ScinServer.default

### DIFF
--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -108,6 +108,7 @@ ScinServer {
 
 	*initClass {
 		Class.initClassTree(Quarks);
+		Class.initClassTree(ScinServerOptions);
 
 
 		default = ScinServer();

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -109,6 +109,7 @@ ScinServer {
 	*initClass {
 		Class.initClassTree(Quarks);
 		Class.initClassTree(ScinServerOptions);
+		Class.initClassTree(ScinServerStatusPoller);
 
 
 		default = ScinServer();

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -1,7 +1,7 @@
 ScinServerOptions {
 	classvar defaultValues;
+	classvar <>quarkPath;
 
-	var <>quarkPath;
 	var <>portNumber;
 	var <>dumpOSC;
 	var <>frameRate;
@@ -18,6 +18,8 @@ ScinServerOptions {
 	var <>onServerError;
 
 	*initClass {
+		Class.initClassTree(Quarks);
+
 		defaultValues = IdentityDictionary.newFrom(
 			(
 				quarkPath: nil,
@@ -34,6 +36,12 @@ ScinServerOptions {
 				vulkanValidation: false
 			)
 		);
+
+		Quarks.installed.do { | quark |
+			if(quark.name == "Scintillator") {
+				quarkPath = quark.localPath;
+			};
+		};
 	}
 
 	*new {
@@ -42,13 +50,6 @@ ScinServerOptions {
 
 	init {
 		defaultValues.keysValuesDo({ |key, value| this.instVarPut(key, value); });
-        if (quarkPath.isNil, {
-            Quarks.installed.do({ |quark, index|
-                if (quark.name == "Scintillator", {
-                    quarkPath = quark.localPath;
-                });
-            });
-        });
 		onServerError = {};
 	}
 
@@ -107,10 +108,7 @@ ScinServer {
 	}
 
 	*initClass {
-		Class.initClassTree(Quarks);
 		Class.initClassTree(ScinServerOptions);
-		Class.initClassTree(ScinServerStatusPoller);
-
 
 		default = ScinServer();
 	}
@@ -122,7 +120,7 @@ ScinServer {
 
 		addr = NetAddr.new("127.0.0.1", options.portNumber);
 
-		scinBinaryPath = options.quarkPath +/+ "bin";
+		scinBinaryPath = ScinServerOptions.quarkPath +/+ "bin";
 		Platform.case(
 			\osx, {
 				scinBinaryPath = scinBinaryPath +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "scinsynth";

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -155,6 +155,7 @@ ScinServer {
 			if (exitCode == 0, {
 				"*** scinsynth exited normally.".postln;
 			}, {
+				statusPoller.serverBooting = false;
 				"*** scinsynth fatal error, code: %".format(exitCode).postln;
 			});
 		});

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -106,6 +106,13 @@ ScinServer {
 		^super.newCopyArgs(options).init;
 	}
 
+	*initClass {
+		Class.initClassTree(Quarks);
+
+
+		default = ScinServer();
+	}
+
 	init {
 		if (options.isNil, {
 			options = ScinServerOptions.new;
@@ -152,10 +159,6 @@ ScinServer {
 			});
 		});
 
-		if (ScinServer.default.isNil, {
-			ScinServer.default = this;
-		});
-		^this;
 	}
 
 	quit {

--- a/tools/TestScripts/makeTestImages.scd
+++ b/tools/TestScripts/makeTestImages.scd
@@ -21,7 +21,7 @@ fork {
     imageOut = quarkPath +/+ "build" +/+ "testing";
 	testDefs = (quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testManifest.yaml").parseYAMLFile;
 	options = ScinServerOptions.new;
-	options.quarkPath = quarkPath;
+	ScinServerOptions.quarkPath = quarkPath;
 	options.logLevel = 2;
 	options.createWindow = false;
 	options.frameRate = 0;


### PR DESCRIPTION
## Purpose and motivation

<!-- Discuss why you made the PR and what it attempts to do -->

Previously, `ScinServer.default` was `nil` until the first time `boot` was called on a server.
This effectively meant that the default server wasn't there.

This PR initialises the default server at the class init stage

## Implementation

<!-- Discuss how you made the PR and why it works that way -->

This PR adds the initClass class method to initialise the classvar `default`.
It also initialises the class tree for `Quarks`, which the server requires to init

## Types of changes

<!-- Delete as needed -->

* Bug fix
* Behaviour change
* Enhancement

## Status

- [x] This PR is ready for review
