### PR TITLE
Automatically install server binaries

### DIFF
--- a/HelpSource/Classes/ScinServerInstaller.schelp
+++ b/HelpSource/Classes/ScinServerInstaller.schelp
@@ -6,6 +6,14 @@ related:: Classes/ScinServer
 DESCRIPTION::
 Scintillator is distributed in two parts, the Quark code and the server binary. The ScinServerInstaller class is distributed with the Scintillator quark and can be used to update or install the server binary.
 
+NOTE::
+By default, the installer is set to automatically install the server binary.
+
+When automatic installation is enabled ScinServerInstaller will check the binary every time SuperCollider starts.
+
+This behaviour can be disabled, see ScinServerInstaller.disableAutoInstall
+::
+
 CLASSMETHODS::
 
 METHOD:: setup
@@ -21,6 +29,16 @@ A boolean, default true. If true, the script will also compute a hash of the dow
 METHOD:: abort
 
 Call to cancel the installation script while it's in progress.
+
+METHOD:: autoInstallEnabled
+Returns true if automatic installation is enabled, otherwise false
+
+METHOD:: disableAutoInstall
+Disables automatic installation
+
+METHOD:: enableAutoInstall
+Enables automatic installation
+
 
 EXAMPLES::
 

--- a/HelpSource/Classes/Scintillator.schelp
+++ b/HelpSource/Classes/Scintillator.schelp
@@ -1,0 +1,20 @@
+TITLE:: Scintillator
+summary:: Scintillator utility class
+categories:: Quarks>Scintillator
+related:: Classes/ScinServer
+
+DESCRIPTION::
+This is a utility class to report information about the Scintillator installation.
+
+
+CLASSMETHODS::
+
+METHOD:: version
+Returns the version string for the Scintillator installation
+
+METHOD:: path
+Returns the path to the Scintillator quark
+
+
+METHOD:: binDir
+Returns the directory for the Scintillator server binary

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -131,13 +131,13 @@ ScinServer {
 
 		Platform.case(
 			\osx, {
-				scinBinaryPath = Scintillator.binPath +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "scinsynth";
+				scinBinaryPath = Scintillator.binDir +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "scinsynth";
 				if (options.swiftshader and: { options.createWindow }, {
 					Error.new("Swiftshader only supports offscreen render contexts." +
 						"See https://github.com/ScintillatorSynth/Scintillator/issues/70.").throw;
 				});
 			},
-			\linux, { scinBinaryPath = Scintillator.binPath +/+ "scinsynth-x86_64.AppImage" },
+			\linux, { scinBinaryPath = Scintillator.binDir +/+ "scinsynth-x86_64.AppImage" },
 			\windows, { Error.new("Windows not (yet) supported!").throw }
 		);
 

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -109,12 +109,6 @@ ScinServer {
 	*initClass {
 		Class.initClassTree(ScinServerOptions);
 
-		if(File.exists(Scintillator.binPath +/+ "disable_auto_install").not) {
-			"*** Scintillator: auto install enabled".postln;
-			"[info] to disable auto install, create an empty file: %".format(Scintillator.binPath+/+"disable_auto_install").postln;
-			ScinServerInstaller.setup;
-		};
-
 		try {
 			default = ScinServer();
 		} { | e |

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -109,9 +109,17 @@ ScinServer {
 	*initClass {
 		Class.initClassTree(ScinServerOptions);
 
-		ScinServerInstaller.setup;
+		if(File.exists(Scintillator.binPath +/+ "disable_auto_install").not) {
+			"*** Scintillator: auto install enabled".postln;
+			"[info] to disable auto install, create an empty file: %".format(Scintillator.binPath+/+"disable_auto_install").postln;
+			ScinServerInstaller.setup;
+		};
 
-		default = ScinServer();
+		try {
+			default = ScinServer();
+		} { | e |
+			"*** %".format(e.what).postln;
+		};
 	}
 
 	init {

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -1,3 +1,9 @@
+Scintillator {
+	*version { ^Quarks.at("Scintillator").version; }
+	*path { ^PathName.new(Scintillator.class.filenameSymbol.asString.dirname).parentPath; }
+	*binPath { ^Scintillator.path +/+ "bin" }
+}
+
 ScinServerOptions {
 	classvar defaultValues;
 
@@ -40,10 +46,6 @@ ScinServerOptions {
 		^super.new.init;
 	}
 
-	*quarkPath {
-		^PathName.new(ScinServerOptions.class.filenameSymbol.asString.dirname).parentPath;
-	}
-
 
 	init {
 		defaultValues.keysValuesDo({ |key, value| this.instVarPut(key, value); });
@@ -51,7 +53,7 @@ ScinServerOptions {
 	}
 
 	asOptionsString {
-		var o = "--quarkDir=" ++ ScinServerOptions.quarkPath.shellQuote;
+		var o = "--quarkDir=" ++ Scintillator.path.shellQuote;
 
 		if (portNumber != defaultValues[\portNumber], {
 			o = o + "--portNumber=" ++ portNumber;
@@ -119,16 +121,15 @@ ScinServer {
 
 		addr = NetAddr.new("127.0.0.1", options.portNumber);
 
-		scinBinaryPath = ScinServerOptions.quarkPath +/+ "bin";
 		Platform.case(
 			\osx, {
-				scinBinaryPath = scinBinaryPath +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "scinsynth";
+				scinBinaryPath = Scintillator.binPath +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "scinsynth";
 				if (options.swiftshader and: { options.createWindow }, {
 					Error.new("Swiftshader only supports offscreen render contexts." +
 						"See https://github.com/ScintillatorSynth/Scintillator/issues/70.").throw;
 				});
 			},
-			\linux, { scinBinaryPath = scinBinaryPath +/+ "scinsynth-x86_64.AppImage" },
+			\linux, { scinBinaryPath = Scintillator.binPath +/+ "scinsynth-x86_64.AppImage" },
 			\windows, { Error.new("Windows not (yet) supported!").throw }
 		);
 

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -1,7 +1,7 @@
 Scintillator {
 	*version { ^Quarks.at("Scintillator").version; }
 	*path { ^PathName.new(Scintillator.class.filenameSymbol.asString.dirname).parentPath; }
-	*binPath { ^Scintillator.path +/+ "bin" }
+	*binDir { ^Scintillator.path +/+ "bin" }
 }
 
 ScinServerOptions {

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -107,6 +107,8 @@ ScinServer {
 	*initClass {
 		Class.initClassTree(ScinServerOptions);
 
+		ScinServerInstaller.setup;
+
 		default = ScinServer();
 	}
 

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -26,6 +26,8 @@ ScinServerInstaller {
 							});
 						});
 
+						"*** ScinServerInstaller: checking installation..".postln;
+
 						if (quarkBinPath.isNil, {
 							"*** Unable to locate Scintillator Quark!".postln;
 							"Something seems wrong with your Scintillator install. Try uninstalling the Quark "

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -24,7 +24,7 @@ ScinServerInstaller {
 					\init, {
 						// Extract Scintillator version from Quark metadata.
 						version = Scintillator.version;
-						quarkBinPath = Scintillator.binPath;
+						quarkBinPath = Scintillator.binDir;
 
 						"*** ScinServerInstaller: checking installation..".postln;
 

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -3,6 +3,10 @@ ScinServerInstaller {
 	classvar routine;
 	classvar continue;
 
+	*initClass {
+		Class.initClassTree(ScinServerOptions);
+	}
+
 	*setup { |cleanup=true, validate=true|
 		if (routine.notNil, {
 			"*** setup already running! Did you mean to call abort?".postln;
@@ -19,12 +23,8 @@ ScinServerInstaller {
 					// Entry point for state machine. Setup variables.
 					\init, {
 						// Extract Scintillator version from Quark metadata.
-						Quarks.installed.do({ |quark, index|
-							if (quark.name == "Scintillator", {
-								quarkBinPath = quark.localPath +/+ "bin";
-								version = quark.version;
-							});
-						});
+						version = Scintillator.version;
+						quarkBinPath = Scintillator.binPath;
 
 						"*** ScinServerInstaller: checking installation..".postln;
 

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -45,7 +45,7 @@ ScinServerInstaller {
 						version = Scintillator.version;
 						quarkBinPath = Scintillator.binDir;
 
-						"*** ScinServerInstaller: checking installation..".postln;
+						"*** ScinServerInstaller: checking installation [%]".format(Scintillator.path).postln;
 
 						if (quarkBinPath.isNil, {
 							"*** Unable to locate Scintillator Quark!".postln;

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -4,7 +4,26 @@ ScinServerInstaller {
 	classvar continue;
 
 	*initClass {
-		Class.initClassTree(ScinServerOptions);
+		if(ScinServerInstaller.autoInstallEnabled) {
+			"*** Scintillator: auto install enabled - to disable, run ScinServerInstaller.disableAutoInstall".postln;
+			ScinServerInstaller.setup;
+		};
+	}
+
+	*autoInstallEnabled {
+		^File.exists(Scintillator.binDir +/+ "disable_auto_install").not;
+	}
+
+	*enableAutoInstall {
+		if(this.autoInstallEnabled.not) {
+			File.delete(Scintillator.binDir+/+"disable_auto_install");
+		};
+	}
+
+	*disableAutoInstall {
+		if(this.autoInstallEnabled) {
+			File.use(Scintillator.binDir+/+"disable_auto_install", "w", {});
+		};
 	}
 
 	*setup { |cleanup=true, validate=true|

--- a/tools/TestScripts/makeTestImages.scd
+++ b/tools/TestScripts/makeTestImages.scd
@@ -17,8 +17,8 @@ fork {
 	testImagesPath = thisProcess.argv[0] +/+ "sourceMedia";
 	c = Condition.new;
 	d = Condition.new;
-    imageOut = ScinServerOptions.quarkPath +/+ "build" +/+ "testing";
-	testDefs = (ScinServerOptions.quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testManifest.yaml").parseYAMLFile;
+    imageOut = Scintillator.path +/+ "build" +/+ "testing";
+	testDefs = (Scintillator.path +/+ "tools" +/+ "TestScripts" +/+ "testManifest.yaml").parseYAMLFile;
 	options = ScinServerOptions.new;
 	options.logLevel = 2;
 	options.createWindow = false;

--- a/tools/TestScripts/oscTest.scd
+++ b/tools/TestScripts/oscTest.scd
@@ -33,7 +33,7 @@ options.height = 200;
 options.dumpOSC = true;
 options.swiftshader = true;
 options.vulkanValidation = true;
-binPath = ScinServerOptions.quarkPath +/+ "bin/scinsynth-x86_64.AppImage";
+binPath = Scintillator.path +/+ "bin/scinsynth-x86_64.AppImage";
 fork {
 	var commandLine, scinPid, udp, c, d, valid, response;
 	var gotFrameRate, numWarn, numError, gotWarn, gotError;
@@ -320,7 +320,7 @@ fork {
 	c.test = false;
 	d.test = false;
 	valid = false;
-	testDefPath = ScinServerOptions.quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testDefs";
+	testDefPath = Scintillator.path +/+ "tools" +/+ "TestScripts" +/+ "testDefs";
 	callbackFunc = OSCFunc.new({ |msg|
 		if (msg[1] == 'xx', {
 			valid = true;


### PR DESCRIPTION
## Purpose and motivation

<!-- Discuss why you made the PR and what it attempts to do -->

This PR builds on #102 (and #101) and calls the installer when initialising the class.

As a result, users only have to install the Quark and recompile the class library.
As a bonus, the binaries will automatically update with the quark.

This may not be the desired approach, the implications of this are quite large.

It also adds a way to enable/disable the auto installation.

## Implementation

<!-- Discuss how you made the PR and why it works that way -->

This PR adds `ScinServerInstaller.setup` to the class initialisation.
Additionally, adds a friendly message that ScinServerInstaller is the thing that's about to run (before, potentially, a bunch of download messages appear).

Adds `ScinServerInstaller.enableAutoInstall` and `ScinServerinstaller.disableAutoInstall` - and `ScinServerInstaller.autoInstallEnabled`.

The disabling of the auto install is accomplished by checking for the file `disable_auto_install` in the binary directory for the quark.

Also, adds `Scintillator` utility class for reporting quark-wide information - and refactors existing code to utilise it.

## Types of changes

<!-- Delete as needed -->
* Enhancement
* Documentation
* Behaviour change

## Status

- [x] This PR is ready for review
