### PR TITLE
Topic/fix server default

### DIFF
--- a/HelpSource/Classes/ScinServerOptions.schelp
+++ b/HelpSource/Classes/ScinServerOptions.schelp
@@ -14,6 +14,9 @@ private::initClass
 METHOD:: new
 Creates a new ScinServerOptions instance with all default options.
 
+METHOD:: quarkPath
+A convenience method that exposes the path to the Scintillator Quark. Used by the link::Classes/ScinServerInstaller:: script, the Scintillator integration test suite and other internal tooling to quickly locate the Scintillator project files.
+
 INSTANCEMETHODS::
 private::init
 
@@ -100,9 +103,6 @@ subsection::Other Methods
 
 METHOD:: asOptionsString
 Returns a string reflecting the current options and which can be passed to the command line of the ScinServer binary on boot. Used primarily by ScinServer code on server boot.
-
-METHOD:: quarkPath
-A convenience method that exposes the path to the Scintillator Quark. Used primarily by the Scintillator integration test suite and other internal tooling to quickly locate the Scintillator project files.
 
 METHOD:: onServerError
 A function, default strong::empty::. This function will be called if the ScinServer object detects an abnormal server exit code.

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -108,6 +108,7 @@ ScinServer {
 
 	*initClass {
 		Class.initClassTree(Quarks);
+		Class.initClassTree(ScinServerOptions);
 
 
 		default = ScinServer();

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -109,6 +109,7 @@ ScinServer {
 	*initClass {
 		Class.initClassTree(Quarks);
 		Class.initClassTree(ScinServerOptions);
+		Class.initClassTree(ScinServerStatusPoller);
 
 
 		default = ScinServer();

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -1,7 +1,7 @@
 ScinServerOptions {
 	classvar defaultValues;
+	classvar <>quarkPath;
 
-	var <>quarkPath;
 	var <>portNumber;
 	var <>dumpOSC;
 	var <>frameRate;
@@ -18,6 +18,8 @@ ScinServerOptions {
 	var <>onServerError;
 
 	*initClass {
+		Class.initClassTree(Quarks);
+
 		defaultValues = IdentityDictionary.newFrom(
 			(
 				quarkPath: nil,
@@ -34,6 +36,12 @@ ScinServerOptions {
 				vulkanValidation: false
 			)
 		);
+
+		Quarks.installed.do { | quark |
+			if(quark.name == "Scintillator") {
+				quarkPath = quark.localPath;
+			};
+		};
 	}
 
 	*new {
@@ -42,13 +50,6 @@ ScinServerOptions {
 
 	init {
 		defaultValues.keysValuesDo({ |key, value| this.instVarPut(key, value); });
-        if (quarkPath.isNil, {
-            Quarks.installed.do({ |quark, index|
-                if (quark.name == "Scintillator", {
-                    quarkPath = quark.localPath;
-                });
-            });
-        });
 		onServerError = {};
 	}
 
@@ -107,10 +108,7 @@ ScinServer {
 	}
 
 	*initClass {
-		Class.initClassTree(Quarks);
 		Class.initClassTree(ScinServerOptions);
-		Class.initClassTree(ScinServerStatusPoller);
-
 
 		default = ScinServer();
 	}
@@ -122,7 +120,7 @@ ScinServer {
 
 		addr = NetAddr.new("127.0.0.1", options.portNumber);
 
-		scinBinaryPath = options.quarkPath +/+ "bin";
+		scinBinaryPath = ScinServerOptions.quarkPath +/+ "bin";
 		Platform.case(
 			\osx, {
 				scinBinaryPath = scinBinaryPath +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "scinsynth";

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -1,6 +1,5 @@
 ScinServerOptions {
 	classvar defaultValues;
-	classvar <>quarkPath;
 
 	var <>portNumber;
 	var <>dumpOSC;
@@ -22,7 +21,6 @@ ScinServerOptions {
 
 		defaultValues = IdentityDictionary.newFrom(
 			(
-				quarkPath: nil,
 				portNumber: 5511,
 				dumpOSC: false,
 				frameRate: -1,
@@ -36,17 +34,16 @@ ScinServerOptions {
 				vulkanValidation: false
 			)
 		);
-
-		Quarks.installed.do { | quark |
-			if(quark.name == "Scintillator") {
-				quarkPath = quark.localPath;
-			};
-		};
 	}
 
 	*new {
 		^super.new.init;
 	}
+
+	*quarkPath {
+		^PathName.new(ScinServerOptions.class.filenameSymbol.asString.dirname).parentPath;
+	}
+
 
 	init {
 		defaultValues.keysValuesDo({ |key, value| this.instVarPut(key, value); });
@@ -54,7 +51,7 @@ ScinServerOptions {
 	}
 
 	asOptionsString {
-		var o = "--quarkDir=" ++ quarkPath;
+		var o = "--quarkDir=" ++ ScinServerOptions.quarkPath;
 
 		if (portNumber != defaultValues[\portNumber], {
 			o = o + "--portNumber=" ++ portNumber;

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -155,6 +155,7 @@ ScinServer {
 			if (exitCode == 0, {
 				"*** scinsynth exited normally.".postln;
 			}, {
+				statusPoller.serverBooting = false;
 				"*** scinsynth fatal error, code: %".format(exitCode).postln;
 			});
 		});

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -106,6 +106,13 @@ ScinServer {
 		^super.newCopyArgs(options).init;
 	}
 
+	*initClass {
+		Class.initClassTree(Quarks);
+
+
+		default = ScinServer();
+	}
+
 	init {
 		if (options.isNil, {
 			options = ScinServerOptions.new;
@@ -152,10 +159,6 @@ ScinServer {
 			});
 		});
 
-		if (ScinServer.default.isNil, {
-			ScinServer.default = this;
-		});
-		^this;
 	}
 
 	quit {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -499,7 +499,7 @@ set(SCIN_REF_IMAGES_PATH "${CMAKE_CURRENT_BINARY_DIR}/ref/src/reference_images")
 
 add_custom_target(test_images
     DEPENDS ${SCLANG_SCIN_CONFIG} scinsynth reference_images-update
-    COMMAND  ${SCIN_RUN_SCLANG} -l "${PROJECT_BINARY_DIR}/testing/sclang_config.yaml" "${PROJECT_SOURCE_DIR}/tools/TestScripts/makeTestImages.scd" "${PROJECT_SOURCE_DIR}" ${SCIN_REF_IMAGES_PATH} ${SCIN_TEST_IMAGES_ENV}
+    COMMAND  ${SCIN_RUN_SCLANG} -l "${PROJECT_BINARY_DIR}/testing/sclang_config.yaml" "${PROJECT_SOURCE_DIR}/tools/TestScripts/makeTestImages.scd" ${SCIN_REF_IMAGES_PATH} ${SCIN_TEST_IMAGES_ENV}
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     VERBATIM
 )
@@ -521,7 +521,7 @@ add_custom_target(compare_images
 add_custom_target(test_osc_commands
     # Artificial dependency to force serialization of the two integration tests during coverage build.
     DEPENDS compare_images
-    COMMAND ${SCIN_RUN_SCLANG} -l "${PROJECT_BINARY_DIR}/testing/sclang_config.yaml" "${PROJECT_SOURCE_DIR}/tools/TestScripts/oscTest.scd" "${PROJECT_SOURCE_DIR}" ${PROJECT_VERSION_MAJOR} ${PROJECT_VERSION_MINOR} ${PROJECT_VERSION_PATCH} ${GIT_BRANCH} ${GIT_COMMIT_HASH} ${SCIN_TEST_OSC_ENV}
+    COMMAND ${SCIN_RUN_SCLANG} -l "${PROJECT_BINARY_DIR}/testing/sclang_config.yaml" "${PROJECT_SOURCE_DIR}/tools/TestScripts/oscTest.scd" ${PROJECT_VERSION_MAJOR} ${PROJECT_VERSION_MINOR} ${PROJECT_VERSION_PATCH} ${GIT_BRANCH} ${GIT_COMMIT_HASH} ${SCIN_TEST_OSC_ENV}
     COMMENT "testing OSC commands on scinsynth"
     VERBATIM
 )

--- a/tools/TestScripts/makeTestImages.scd
+++ b/tools/TestScripts/makeTestImages.scd
@@ -21,7 +21,7 @@ fork {
     imageOut = quarkPath +/+ "build" +/+ "testing";
 	testDefs = (quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testManifest.yaml").parseYAMLFile;
 	options = ScinServerOptions.new;
-	options.quarkPath = quarkPath;
+	ScinServerOptions.quarkPath = quarkPath;
 	options.logLevel = 2;
 	options.createWindow = false;
 	options.frameRate = 0;

--- a/tools/TestScripts/makeTestImages.scd
+++ b/tools/TestScripts/makeTestImages.scd
@@ -1,27 +1,25 @@
 // Generates a series of images for validation of individual VGens and
 // integration testing of the render stack.
 (
-var quarkPath, testImagesPath, imageOut, options, server, c, d, testDefs, keptScinths;
-if (thisProcess.argv.size < 2, {
-    "requires at least two arguments, the path to the Scintillator Quark directory followed by the path to the test images repository.".postln;
+var testImagesPath, imageOut, options, server, c, d, testDefs, keptScinths;
+if (thisProcess.argv.size < 1, {
+    "requires at least one argument, the path to the test images repository.".postln;
     "*** SCRIPT FAILED ***".postln;
     -1.exit;
 });
 // Remaining arguments, if any, should be environment variables to set before invoking the server.
-thisProcess.argv[2..].do({ |pairs|
+thisProcess.argv[1..].do({ |pairs|
     var splitPairs = pairs.split($=);
     "setting environment variable % to %".format(splitPairs[0], splitPairs[1]).postln;
     splitPairs[0].setenv(splitPairs[1]);
 });
 fork {
-	quarkPath = thisProcess.argv[0];
-	testImagesPath = thisProcess.argv[1] +/+ "sourceMedia";
+	testImagesPath = thisProcess.argv[0] +/+ "sourceMedia";
 	c = Condition.new;
 	d = Condition.new;
-    imageOut = quarkPath +/+ "build" +/+ "testing";
-	testDefs = (quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testManifest.yaml").parseYAMLFile;
+    imageOut = ScinServerOptions.quarkPath +/+ "build" +/+ "testing";
+	testDefs = (ScinServerOptions.quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testManifest.yaml").parseYAMLFile;
 	options = ScinServerOptions.new;
-	ScinServerOptions.quarkPath = quarkPath;
 	options.logLevel = 2;
 	options.createWindow = false;
 	options.frameRate = 0;

--- a/tools/TestScripts/oscTest.scd
+++ b/tools/TestScripts/oscTest.scd
@@ -2,32 +2,29 @@
 // in sclang and sends messages directly to the server.
 // TODO: add a timeout on the Condition waits so that missing messages don't hang this script.
 (
-var quarkPath, versionMajor, versionMinor, versionPatch, gitBranch, gitHash, options, binPath;
+var versionMajor, versionMinor, versionPatch, gitBranch, gitHash, options, binPath;
 var scriptFailed = "*** SCRIPT FAILED ***";
 var scriptOk = "*** SCRIPT OK ***";
-if (thisProcess.argv.size < 6, {
-	"requires at least six arguments:".postln;
-	"  the path to the Scintillator Quark directory".postln;
+if (thisProcess.argv.size < 5, {
+	"requires at least five arguments:".postln;
 	"  Scintillator major, minor, and patch version numbers".postln;
 	"  Git branch name and first seven hex digits of the commit hash".postln;
 	scriptFailed.postln;
 	-1.exit;
 });
 // Remaining arguments, if any, should be environment variables to set before invoking the server.
-thisProcess.argv[6..].do({ |pairs|
+thisProcess.argv[5..].do({ |pairs|
     var splitPairs = pairs.split($=);
     "setting environment variable % to %".format(splitPairs[0], splitPairs[1]).postln;
     splitPairs[0].setenv(splitPairs[1]);
 });
 OSCFunc.trace(true);
-quarkPath = thisProcess.argv[0];
-versionMajor = thisProcess.argv[1].asInteger;
-versionMinor = thisProcess.argv[2].asInteger;
-versionPatch = thisProcess.argv[3].asInteger;
-gitBranch = thisProcess.argv[4].asSymbol;
-gitHash = thisProcess.argv[5].asSymbol;
+versionMajor = thisProcess.argv[0].asInteger;
+versionMinor = thisProcess.argv[1].asInteger;
+versionPatch = thisProcess.argv[2].asInteger;
+gitBranch = thisProcess.argv[3].asSymbol;
+gitHash = thisProcess.argv[4].asSymbol;
 options = ScinServerOptions.new;
-options.quarkPath = quarkPath;
 options.logLevel = 2;
 options.createWindow = false;
 options.frameRate = 0;
@@ -36,7 +33,7 @@ options.height = 200;
 options.dumpOSC = true;
 options.swiftshader = true;
 options.vulkanValidation = true;
-binPath = quarkPath +/+ "bin/scinsynth-x86_64.AppImage";
+binPath = ScinServerOptions.quarkPath +/+ "bin/scinsynth-x86_64.AppImage";
 fork {
 	var commandLine, scinPid, udp, c, d, valid, response;
 	var gotFrameRate, numWarn, numError, gotWarn, gotError;
@@ -323,7 +320,7 @@ fork {
 	c.test = false;
 	d.test = false;
 	valid = false;
-	testDefPath = quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testDefs";
+	testDefPath = ScinServerOptions.quarkPath +/+ "tools" +/+ "TestScripts" +/+ "testDefs";
 	callbackFunc = OSCFunc.new({ |msg|
 		if (msg[1] == 'xx', {
 			valid = true;


### PR DESCRIPTION
## Purpose and motivation

Patch on top of @jrsurge pull request #102, trying to get the build servers to be happy with it.

## Implementation

Changes the `quarkPath` variable inside of `ScinServerOptions` to be a class function. Uses the path of the class filename instead of querying the quark system to determine the install path of the quark.

TODO:

- [x] Update `ScinServerOptions` documentation to reflect the refactor

## Types of changes

* Bug fix
* Behaviour change
* Enhancement

## Status

- [x] This PR is ready for review
