### PR TITLE
Rename fragment rate methods from .fg to .fr

### DIFF
--- a/HelpSource/Classes/Clamp.schelp
+++ b/HelpSource/Classes/Clamp.schelp
@@ -8,7 +8,7 @@ DESCRIPTION::
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 (describe method here)
 
 ARGUMENT:: x

--- a/HelpSource/Classes/Distance.schelp
+++ b/HelpSource/Classes/Distance.schelp
@@ -8,7 +8,7 @@ Distance computes the distance between two vectors by calculating the length of 
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -38,17 +38,17 @@ code::
 // quickly the dot will drive the length to the clamp values as distance from each
 // Lissajous point increases.
 ~k = ScinthDef.new(\k, { |dot = 0.5|
-	var rx = ScinOsc.fg(freq: 1.5, mul: 0.9, add: 0.0);
-	var ry = ScinOsc.fg(freq: 1, phase: pi / 4, mul: 0.9, add: 0.0);
-	var gx = ScinOsc.fg(freq: 0.5, phase: pi / 2, mul: 0.9, add: 0.0);
-	var gy = ScinOsc.fg(freq: 1.25, mul: 1.0, add: 0.0);
-	var bx = ScinOsc.fg(freq: 0.75, phase: pi / 3, mul: 0.9, add: 0.0);
-	var by = ScinOsc.fg(phase: 3 * pi / 4, mul: 0.9, add: 0.0);
-	var pos = NormPos.fg;
-	var r = Clamp.fg(1.0 - (Distance.fg(Vec2.fg(rx, ry), pos) / dot), 0.0, 1.0);
-	var g = Clamp.fg(1.0 - (Distance.fg(Vec2.fg(gx, gy), pos) / dot), 0.0, 1.0);
-	var b = Clamp.fg(1.0 - (Distance.fg(Vec2.fg(bx, by), pos) / dot), 0.0, 1.0);
-	RGBOut.fg(r, g, b);
+	var rx = ScinOsc.fr(freq: 1.5, mul: 0.9, add: 0.0);
+	var ry = ScinOsc.fr(freq: 1, phase: pi / 4, mul: 0.9, add: 0.0);
+	var gx = ScinOsc.fr(freq: 0.5, phase: pi / 2, mul: 0.9, add: 0.0);
+	var gy = ScinOsc.fr(freq: 1.25, mul: 1.0, add: 0.0);
+	var bx = ScinOsc.fr(freq: 0.75, phase: pi / 3, mul: 0.9, add: 0.0);
+	var by = ScinOsc.fr(phase: 3 * pi / 4, mul: 0.9, add: 0.0);
+	var pos = NormPos.fr;
+	var r = Clamp.fr(1.0 - (Distance.fr(Vec2.fr(rx, ry), pos) / dot), 0.0, 1.0);
+	var g = Clamp.fr(1.0 - (Distance.fr(Vec2.fr(gx, gy), pos) / dot), 0.0, 1.0);
+	var b = Clamp.fr(1.0 - (Distance.fr(Vec2.fr(bx, by), pos) / dot), 0.0, 1.0);
+	RGBOut.fr(r, g, b);
 }).add;
 )
 

--- a/HelpSource/Classes/Distance.schelp
+++ b/HelpSource/Classes/Distance.schelp
@@ -38,12 +38,12 @@ code::
 // quickly the dot will drive the length to the clamp values as distance from each
 // Lissajous point increases.
 ~k = ScinthDef.new(\k, { |dot = 0.5|
-	var rx = ScinOsc.fr(freq: 1.5, mul: 0.9, add: 0.0);
-	var ry = ScinOsc.fr(freq: 1, phase: pi / 4, mul: 0.9, add: 0.0);
-	var gx = ScinOsc.fr(freq: 0.5, phase: pi / 2, mul: 0.9, add: 0.0);
-	var gy = ScinOsc.fr(freq: 1.25, mul: 1.0, add: 0.0);
-	var bx = ScinOsc.fr(freq: 0.75, phase: pi / 3, mul: 0.9, add: 0.0);
-	var by = ScinOsc.fr(phase: 3 * pi / 4, mul: 0.9, add: 0.0);
+	var rx = VSinOsc.fr(freq: 1.5, mul: 0.9, add: 0.0);
+	var ry = VSinOsc.fr(freq: 1, phase: pi / 4, mul: 0.9, add: 0.0);
+	var gx = VSinOsc.fr(freq: 0.5, phase: pi / 2, mul: 0.9, add: 0.0);
+	var gy = VSinOsc.fr(freq: 1.25, mul: 1.0, add: 0.0);
+	var bx = VSinOsc.fr(freq: 0.75, phase: pi / 3, mul: 0.9, add: 0.0);
+	var by = VSinOsc.fr(phase: 3 * pi / 4, mul: 0.9, add: 0.0);
 	var pos = NormPos.fr;
 	var r = Clamp.fr(1.0 - (Distance.fr(Vec2.fr(rx, ry), pos) / dot), 0.0, 1.0);
 	var g = Clamp.fr(1.0 - (Distance.fr(Vec2.fr(gx, gy), pos) / dot), 0.0, 1.0);

--- a/HelpSource/Classes/FragCoord.schelp
+++ b/HelpSource/Classes/FragCoord.schelp
@@ -8,7 +8,7 @@ FragCoord exposes the underlying GLSL primitive code::gl_FragCoord::. It returns
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -31,10 +31,10 @@ code::
 // to provide screen width and height as constants to the Scinth.
 (
 ~f = ScinthDef.new(\f, {
-	RGBOut.fg(
-		VX.fg(FragCoord.fg) / ~o.width,
+	RGBOut.fr(
+		VX.fr(FragCoord.fr) / ~o.width,
 		0.0,
-		VY.fg(FragCoord.fg) / ~o.height);
+		VY.fr(FragCoord.fr) / ~o.height);
 }).add;
 )
 

--- a/HelpSource/Classes/ImageBuffer.schelp
+++ b/HelpSource/Classes/ImageBuffer.schelp
@@ -75,11 +75,11 @@ code::
 
 (
 ~f = ScinthDef.new(\chromaKey, { |r, g, b, key = 0.25|
-	var m = Sampler.fg(~molly, TexPos.fg);
-	var s = Sampler.fg(~storm, TexPos.fg);
-	var dist = Length.fg(m - Vec4.fg(r, g, b, 1.0));
-	var pick = Step.fg(key, dist);
-	VecMix.fg(s, m, pick);
+	var m = Sampler.fr(~molly, TexPos.fr);
+	var s = Sampler.fr(~storm, TexPos.fr);
+	var dist = Length.fr(m - Vec4.fr(r, g, b, 1.0));
+	var pick = Step.fr(key, dist);
+	VecMix.fr(s, m, pick);
 }).add;
 )
 

--- a/HelpSource/Classes/Length.schelp
+++ b/HelpSource/Classes/Length.schelp
@@ -8,7 +8,7 @@ Length computes the length of the provided vector as the square root of the sum 
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -37,12 +37,12 @@ code::
 // the magnitude of the magnetic flux vector at each point,
 // to generate the black and white image.
 ~k = ScinthDef.new(\k, {
-	var pos = NormPos.fg;
-	var r = Vec3.fg(VX.fg(pos), VY.fg(pos), 0.0);
-	var magR = Length.fg(r);
-	var m = Vec3.fg(0.0, 0.1, 0.0);
-	var flux = Cross.fg(m, r) / magR.cubed;
-	BWOut.fg(Clamp.fg(Length.fg(flux), 0.0, 1.0));
+	var pos = NormPos.fr;
+	var r = Vec3.fr(VX.fr(pos), VY.fr(pos), 0.0);
+	var magR = Length.fr(r);
+	var m = Vec3.fr(0.0, 0.1, 0.0);
+	var flux = Cross.fr(m, r) / magR.cubed;
+	BWOut.fr(Clamp.fr(Length.fr(flux), 0.0, 1.0));
 }).add;
 )
 

--- a/HelpSource/Classes/NormPos.schelp
+++ b/HelpSource/Classes/NormPos.schelp
@@ -10,7 +10,7 @@ image::NormPosLayout.png::
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -30,11 +30,11 @@ code::
 ~k = ScinthDef.new(\k, {
 	// This radius will go from black at the center where NormPos is close to zero
 	// and increase to > 1 at the edges of the image.
-	var r = Length.fg(NormPos.fg);
+	var r = Length.fr(NormPos.fr);
 	// We use the Step function to clip all values of r > 1 to make the cirle more
 	// visually obvious.
-	var clip = 1.0 - Step.fg(1.0, r);
-	BWOut.fg(r * clip);
+	var clip = 1.0 - Step.fr(1.0, r);
+	BWOut.fr(r * clip);
 }).add;
 )
 

--- a/HelpSource/Classes/ScinOsc.schelp
+++ b/HelpSource/Classes/ScinOsc.schelp
@@ -8,7 +8,7 @@ The ScinOsc, a play on the soft "s" in Scintillator and the link::Classes/SinOsc
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -46,10 +46,10 @@ code::
 // Scintillator currently can't "autosplat" defaults to
 // higher-dimensional arguments.
 ~k = ScinthDef.new(\k, { |dot = 0.5|
-	var r = Length.fg(NormPos.fg);
-	var rgb = ScinOsc.fg(Vec3.fg(r, 2.0 * r, 3.0 * r),
-		Vec3.fg, Splat3.fg(0.5), Splat3.fg(0.5));
-	RGBOut.fg(VX.fg(rgb), VY.fg(rgb), VZ.fg(rgb));
+	var r = Length.fr(NormPos.fr);
+	var rgb = ScinOsc.fr(Vec3.fr(r, 2.0 * r, 3.0 * r),
+		Vec3.fr, Splat3.fr(0.5), Splat3.fr(0.5));
+	RGBOut.fr(VX.fr(rgb), VY.fr(rgb), VZ.fr(rgb));
 }).add;
 )
 

--- a/HelpSource/Classes/ScinServer.schelp
+++ b/HelpSource/Classes/ScinServer.schelp
@@ -176,7 +176,7 @@ fork {
 
 	// Send a ScinthDef to the server
 	~def = ScinthDef.new(\t, { |sx = 1.0, sy = 2.0|
-		BWOut.fg(ScinOsc.fg(1.0, Length.fg(NormPos.fg * Vec2.fg(sx, sy))));
+		BWOut.fr(ScinOsc.fr(1.0, Length.fr(NormPos.fr * Vec2.fr(sx, sy))));
 	}).add;
 
 	// Wait for the server to complete building the ScinthDef just provided.

--- a/HelpSource/Classes/ScinServer.schelp
+++ b/HelpSource/Classes/ScinServer.schelp
@@ -176,7 +176,7 @@ fork {
 
 	// Send a ScinthDef to the server
 	~def = ScinthDef.new(\t, { |sx = 1.0, sy = 2.0|
-		BWOut.fr(ScinOsc.fr(1.0, Length.fr(NormPos.fr * Vec2.fr(sx, sy))));
+		BWOut.fr(VSinOsc.fr(1.0, Length.fr(NormPos.fr * Vec2.fr(sx, sy))));
 	}).add;
 
 	// Wait for the server to complete building the ScinthDef just provided.

--- a/HelpSource/Classes/Scinth.schelp
+++ b/HelpSource/Classes/Scinth.schelp
@@ -52,7 +52,7 @@ EXAMPLES::
 code::
 (
 ~t = ScinthDef.new(\t, { |g, b|
-	RGBOut.fr(ScinOsc.fr(VX.fr(NormPos.fr)), g, b);
+	RGBOut.fr(VSinOsc.fr(VX.fr(NormPos.fr)), g, b);
 }).add;
 )
 

--- a/HelpSource/Classes/Scinth.schelp
+++ b/HelpSource/Classes/Scinth.schelp
@@ -52,7 +52,7 @@ EXAMPLES::
 code::
 (
 ~t = ScinthDef.new(\t, { |g, b|
-	RGBOut.fg(ScinOsc.fg(VX.fg(NormPos.fg)), g, b);
+	RGBOut.fr(ScinOsc.fr(VX.fr(NormPos.fr)), g, b);
 }).add;
 )
 

--- a/HelpSource/Classes/ScinthDef.schelp
+++ b/HelpSource/Classes/ScinthDef.schelp
@@ -30,7 +30,7 @@ code::
 (
 ~vquad = ScinthDef.new(\vquad, {
 	var length = Length.fr(NormPos.fr);
-	ScinOsc.fr(
+	VSinOsc.fr(
 		Vec4.fr(1.0, 1.5, 2.0, 3.0),
 		Vec4.fr(length, length * 2, length * 4, length * 8),
 		Splat4.fr(0.5),
@@ -41,9 +41,9 @@ code::
 
 From the top, the link::Classes/NormPos:: VGen takes no inputs and produces a single two-dimensional output, which is the sole input to the link::Classes/Length:: VGen. The Length VGen can accept inputs with dimesions from 1 to 4, and always produces a single-dimensional output, the scalar length of the input vector, in this case stored in the code::length:: variable.
 
-The link::Classes/ScinOsc:: VGen takes four inputs, just like its analagous audio class link::Classes/SinOsc::, and they are code::freq::, code::phase::, code::mul::, and code::add::. The default values of code::mul:: and code::add:: are adjusted to reflect the fact that VGens produce output within the range of [0.0, 1.0] instead of the audio [-1.0, 1.0] range. Like Length, ScinOsc can accept inputs from 1 to 4 dimensions, but unlike Length, it will produce a single output of the same dimension as the inputs. So, a ScinOsc with 4 four-dimensional inputs, like in this case, will produce a single four-dimensional output.
+The link::Classes/VSinOsc:: VGen takes four inputs, just like its analagous audio class link::Classes/SinOsc::, and they are code::freq::, code::phase::, code::mul::, and code::add::. The default values of code::mul:: and code::add:: are adjusted to reflect the fact that VGens produce output within the range of [0.0, 1.0] instead of the audio [-1.0, 1.0] range. Like Length, VSinOsc can accept inputs from 1 to 4 dimensions, but unlike Length, it will produce a single output of the same dimension as the inputs. So, a VSinOsc with 4 four-dimensional inputs, like in this case, will produce a single four-dimensional output.
 
-The code::freq:: and code::phase:: arguments to ScinOsc here use the link::Classes/Vec4:: VGen, which takes 4 one-dimensional inputs and merges those into a single four-dimensional output. The code::mul:: and code::add:: arguments are left to defaults, but because ScinOsc requires that all of its inputs are the same dimension, we use the link::Classes/Splat4:: VGen to make a four-dimensional vector out of a single one-dimensional input. Because the default arguments to code::mul:: and code::add:: are single-dimensional, we have to explicitly specify the higher-dimensional inputs to the ScinOsc, or it will fail dimensional analysis.
+The code::freq:: and code::phase:: arguments to VSinOsc here use the link::Classes/Vec4:: VGen, which takes 4 one-dimensional inputs and merges those into a single four-dimensional output. The code::mul:: and code::add:: arguments are left to defaults, but because VSinOsc requires that all of its inputs are the same dimension, we use the link::Classes/Splat4:: VGen to make a four-dimensional vector out of a single one-dimensional input. Because the default arguments to code::mul:: and code::add:: are single-dimensional, we have to explicitly specify the higher-dimensional inputs to the VSinOsc, or it will fail dimensional analysis.
 
 This VGen will perform a single sine computation per pixel in the output, producing the four-dimensional output signal with is interpreted by the graphics hardware as the red, blue, green, and alpha color values at each pixel to produce an image.
 
@@ -91,7 +91,7 @@ examples::
 code::
 (
 ~t = ScinthDef.new(\t, {
-	BWOut.fr(ScinOsc.fr(1.0, Length.fr(NormPos.fr)));
+	BWOut.fr(VSinOsc.fr(1.0, Length.fr(NormPos.fr)));
 });
 )
 

--- a/HelpSource/Classes/ScinthDef.schelp
+++ b/HelpSource/Classes/ScinthDef.schelp
@@ -29,12 +29,12 @@ When constructing a ScinthDef the VGens are subject to a validation step called 
 code::
 (
 ~vquad = ScinthDef.new(\vquad, {
-	var length = Length.fg(NormPos.fg);
-	ScinOsc.fg(
-		Vec4.fg(1.0, 1.5, 2.0, 3.0),
-		Vec4.fg(length, length * 2, length * 4, length * 8),
-		Splat4.fg(0.5),
-		Splat4.fg(0.5));
+	var length = Length.fr(NormPos.fr);
+	ScinOsc.fr(
+		Vec4.fr(1.0, 1.5, 2.0, 3.0),
+		Vec4.fr(length, length * 2, length * 4, length * 8),
+		Splat4.fr(0.5),
+		Splat4.fr(0.5));
 }).add;
 )
 ::
@@ -91,7 +91,7 @@ examples::
 code::
 (
 ~t = ScinthDef.new(\t, {
-	BWOut.fg(ScinOsc.fg(1.0, Length.fg(NormPos.fg)));
+	BWOut.fr(ScinOsc.fr(1.0, Length.fr(NormPos.fr)));
 });
 )
 

--- a/HelpSource/Classes/Splat2.schelp
+++ b/HelpSource/Classes/Splat2.schelp
@@ -8,7 +8,7 @@ Like its partner classes link::Classes/Splat3:: and link::Classes/Splat4::, copi
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 
@@ -27,7 +27,7 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Splat2.fg(1.0);
-var x = VX.fg(v); // x: 1
-var y = VY.fg(v); // y: 1
+var v = Splat2.fr(1.0);
+var x = VX.fr(v); // x: 1
+var y = VY.fr(v); // y: 1
 ::

--- a/HelpSource/Classes/Splat3.schelp
+++ b/HelpSource/Classes/Splat3.schelp
@@ -8,7 +8,7 @@ Like its partner classes link::Classes/Splat2:: and link::Classes/Splat4::, copi
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 
@@ -27,8 +27,8 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Splat3.fg(1.0);
-var x = VX.fg(v); // x: 1
-var y = VY.fg(v); // y: 1
-var z = VZ.fg(v); // z: 1
+var v = Splat3.fr(1.0);
+var x = VX.fr(v); // x: 1
+var y = VY.fr(v); // y: 1
+var z = VZ.fr(v); // z: 1
 ::

--- a/HelpSource/Classes/Splat4.schelp
+++ b/HelpSource/Classes/Splat4.schelp
@@ -8,7 +8,7 @@ Like its partner classes link::Classes/Splat2:: and link::Classes/Splat3::, copi
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 
@@ -27,9 +27,9 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Splat4.fg(1.0);
-var x = VX.fg(v); // x: 1
-var y = VY.fg(v); // y: 1
-var z = VZ.fg(v); // z: 1
-var w = VW.fg(v); // w: 1
+var v = Splat4.fr(1.0);
+var x = VX.fr(v); // x: 1
+var y = VY.fr(v); // y: 1
+var z = VZ.fr(v); // z: 1
+var w = VW.fr(v); // w: 1
 ::

--- a/HelpSource/Classes/TexPos.schelp
+++ b/HelpSource/Classes/TexPos.schelp
@@ -8,7 +8,7 @@ TexPos provides a texture coordinate representing the position on the underlying
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -38,7 +38,7 @@ code::
 
 (
 ~f = ScinthDef.new(\f, {
-	Sampler.fg(~ib, TexPos.fg);
+	Sampler.fr(~ib, TexPos.fr);
 }).add;
 )
 
@@ -61,8 +61,8 @@ code::
 ~f = ScinthDef.new(\f, {
 	var screenAspect = ~o.width / ~o.height;
 	var imageAspect = ~ib.width / ~ib.height;
-	Sampler.fg(~ib,
-		TexPos.fg * Vec2.fg(screenAspect, 1.0) / Vec2.fg(imageAspect, 1.0));
+	Sampler.fr(~ib,
+		TexPos.fr * Vec2.fr(screenAspect, 1.0) / Vec2.fr(imageAspect, 1.0));
 }).add;
 )
 

--- a/HelpSource/Classes/VSaw.schelp
+++ b/HelpSource/Classes/VSaw.schelp
@@ -8,7 +8,7 @@ Similar to its analog sibling link::Classes/LFSaw:: the VSaw is a video sawtooth
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -39,9 +39,9 @@ code::
 // move outward over time.
 (
 ~t = ScinthDef.new(\t, {
-	var pos = NormPos.fg.abs.neg;
-	var z = min(VX.fg(pos), VY.fg(pos));
-	BWOut.fg(Step.fg(0.5, VSaw.fg(freq: 5, phase: z)));
+	var pos = NormPos.fr.abs.neg;
+	var z = min(VX.fr(pos), VY.fr(pos));
+	BWOut.fr(Step.fr(0.5, VSaw.fr(freq: 5, phase: z)));
 }).add;
 )
 

--- a/HelpSource/Classes/VSinOsc.schelp
+++ b/HelpSource/Classes/VSinOsc.schelp
@@ -1,10 +1,10 @@
-TITLE:: ScinOsc
+TITLE:: VSinOsc
 summary:: Multidimensional sinusoidal video oscillator
 categories:: Quarks>Scintillator>VGens>Video Oscillators
 related:: Classes/SinOsc
 
 DESCRIPTION::
-The ScinOsc, a play on the soft "s" in Scintillator and the link::Classes/SinOsc:: UGen, is a sinusoidal oscillator. It can process inputs of one to four dimensions and produces an output in the same dimension. The arguments parallel the arguments used by link::Classes/SinOsc::, with the only difference being that the default code::mul:: and code::add:: argument values are modified to support producing a sin output range within code::[0, 1]:: instead of the audio range code::[-1, 1]::.
+VSinOsc, just like the audio UGen link::Classes/SinOsc:: UGen, is a sinusoidal oscillator. It can process inputs of one to four dimensions and produces an output in the same dimension. The arguments parallel the arguments used by link::Classes/SinOsc::, with the only difference being that the default code::mul:: and code::add:: argument values are modified to support producing a sin output range within code::[0, 1]:: instead of the audio range code::[-1, 1]::.
 
 CLASSMETHODS::
 
@@ -39,15 +39,15 @@ EXAMPLES::
 code::
 (
 // This example demonstrates using the three-dimensional
-// ScinOsc to produce separate red, green, and blue
+// VSinOsc to produce separate red, green, and blue
 // channel outputs. Note that all arguments have to be
-// provided to the higher dimensional ScinOsc instances,
+// provided to the higher dimensional VSinOsc instances,
 // because the defaults are only 1-dimensional, and
 // Scintillator currently can't "autosplat" defaults to
 // higher-dimensional arguments.
 ~k = ScinthDef.new(\k, { |dot = 0.5|
 	var r = Length.fr(NormPos.fr);
-	var rgb = ScinOsc.fr(Vec3.fr(r, 2.0 * r, 3.0 * r),
+	var rgb = VSinOsc.fr(Vec3.fr(r, 2.0 * r, 3.0 * r),
 		Vec3.fr, Splat3.fr(0.5), Splat3.fr(0.5));
 	RGBOut.fr(VX.fr(rgb), VY.fr(rgb), VZ.fr(rgb));
 }).add;
@@ -58,4 +58,4 @@ code::
 )
 ::
 
-image::ScinOsc.png::
+image::VSinOsc.png::

--- a/HelpSource/Classes/VW.schelp
+++ b/HelpSource/Classes/VW.schelp
@@ -8,7 +8,7 @@ Like its sibling classes link::Classes/VX::, link::Classes/VY::, link::Classes/V
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -25,6 +25,6 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec4.fg(1, 2, 3, 4);
-var w = VW.fg(v); // w: 4
+var v = Vec4.fr(1, 2, 3, 4);
+var w = VW.fr(v); // w: 4
 ::

--- a/HelpSource/Classes/VX.schelp
+++ b/HelpSource/Classes/VX.schelp
@@ -8,7 +8,7 @@ Like its sibling classes link::Classes/VY::, link::Classes/VZ::, link::Classes/V
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -27,6 +27,6 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec4.fg(1, 2, 3, 4);
-var x = VX.fg(v); // x: 1
+var v = Vec4.fr(1, 2, 3, 4);
+var x = VX.fr(v); // x: 1
 ::

--- a/HelpSource/Classes/VY.schelp
+++ b/HelpSource/Classes/VY.schelp
@@ -8,7 +8,7 @@ Like its sibling classes link::Classes/VX::, link::Classes/VZ::, link::Classes/V
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -27,6 +27,6 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec4.fg(1, 2, 3, 4);
-var y = VY.fg(v); // y: 2
+var v = Vec4.fr(1, 2, 3, 4);
+var y = VY.fr(v); // y: 2
 ::

--- a/HelpSource/Classes/VZ.schelp
+++ b/HelpSource/Classes/VZ.schelp
@@ -8,7 +8,7 @@ Like its sibling classes link::Classes/VX::, link::Classes/VY::, link::Classes/V
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -26,6 +26,6 @@ private::inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec4.fg(1, 2, 3, 4);
-var z = VZ.fg(v); // z: 3
+var v = Vec4.fr(1, 2, 3, 4);
+var z = VZ.fr(v); // z: 3
 ::

--- a/HelpSource/Classes/Vec2.schelp
+++ b/HelpSource/Classes/Vec2.schelp
@@ -8,7 +8,7 @@ Like its partner classes link::Classes/Vec4:: and link::Classes/Vec3::, Vec2 pac
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -28,7 +28,7 @@ private:: inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec3.fg(1, 2);
-var x = VX.fg(v); // x: 1
-var y = VY.fg(v); // y: 2
+var v = Vec3.fr(1, 2);
+var x = VX.fr(v); // x: 1
+var y = VY.fr(v); // y: 2
 ::

--- a/HelpSource/Classes/Vec3.schelp
+++ b/HelpSource/Classes/Vec3.schelp
@@ -8,7 +8,7 @@ Like its partner classes link::Classes/Vec4:: and link::Classes/Vec2::, Vec3 pac
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -31,8 +31,8 @@ private:: inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec3.fg(1, 2, 3);
-var x = VX.fg(v); // x: 1
-var y = VY.fg(v); // y: 2
-var z = VZ.fg(v); // z: 3
+var v = Vec3.fr(1, 2, 3);
+var x = VX.fr(v); // x: 1
+var y = VY.fr(v); // y: 2
+var z = VZ.fr(v); // z: 3
 ::

--- a/HelpSource/Classes/Vec4.schelp
+++ b/HelpSource/Classes/Vec4.schelp
@@ -8,7 +8,7 @@ Like its partner classes link::Classes/Vec3:: and link::Classes/Vec2::, Vec4 pac
 
 CLASSMETHODS::
 
-METHOD:: fg
+METHOD:: fr
 
 strong::dimensions::
 table::
@@ -35,9 +35,9 @@ private:: inputDimensions, outputDimensions
 EXAMPLES::
 
 code::
-var v = Vec4.fg(1, 2, 3, 4);
-var x = VX.fg(v); // x: 1
-var y = VY.fg(v); // y: 2
-var z = VZ.fg(v); // z: 3
-var w = VW.fg(v); // w: 4
+var v = Vec4.fr(1, 2, 3, 4);
+var x = VX.fr(v); // x: 1
+var y = VY.fr(v); // y: 2
+var z = VZ.fr(v); // z: 3
+var w = VW.fr(v); // w: 4
 ::

--- a/HelpSource/Guides/Scintillator-Parallel-Classes.schelp
+++ b/HelpSource/Guides/Scintillator-Parallel-Classes.schelp
@@ -20,7 +20,7 @@ For an exhaustive list of all supported Scintillator VGens, see the link::Guides
 
 table::
 ## strong::Parallel UGen:: || strong::VGen:: || strong::comments::
-## link::Classes/SinOsc:: || link::Classes/ScinOsc:: || Sinusoidal oscillator.
+## link::Classes/SinOsc:: || link::Classes/VSinOsc:: || Sinusoidal oscillator.
 ## link::Classes/LFSaw:: || link::Classes/VSaw:: || Sawtooth oscillator.
 ## link::Classes/PlayBuf:: || link::Classes/Sampler:: || Image sampling VGen.
 ## link::Classes/BufFrames:: || link::Classes/TextureSize:: || Dimensions of image buffer in pixels.

--- a/HelpSource/Guides/Scintillator-User-Guide.schelp
+++ b/HelpSource/Guides/Scintillator-User-Guide.schelp
@@ -68,7 +68,7 @@ The simplest imaginable link::Classes/ScinthDef:: sets the same color everywhere
 code::
 (
 ~red = ScinthDef.new(\red, {
-	RGBOut.fg(1.0, 0.0, 0.0);
+	RGBOut.fr(1.0, 0.0, 0.0);
 }).add;
 )
 ::
@@ -102,7 +102,7 @@ Another point to note is that while audio signals normally operate in the domain
 code::
 (
 ~w = ScinthDef.new(\wave, { |f=1|
-	BWOut.fg(ScinOsc.fg(freq: f));
+	BWOut.fr(ScinOsc.fr(freq: f));
 }).add;
 )
 
@@ -136,7 +136,7 @@ code::
 
 (
 ~spot = ScinthDef.new(\spot, {
-	BWOut.fg(Length.fg(NormPos.fg));
+	BWOut.fr(Length.fr(NormPos.fr));
 }).add;
 )
 
@@ -167,10 +167,10 @@ code::
 
 (
 ~rings = ScinthDef.new(\rings, {
-	var rad = Length.fg(NormPos.fg);  // rad is one-dimensional
-	var rgb = rad * Vec3.fg(31, 41, 61); // rgb is 3D
+	var rad = Length.fr(NormPos.fr);  // rad is one-dimensional
+	var rgb = rad * Vec3.fr(31, 41, 61); // rgb is 3D
 	rgb = 0.5 + (rgb.sin * 0.5); // This is all 3D math!
-	Vec4.fg(VX.fg(rgb), VY.fg(rgb), VZ.fg(rgb), 1.0);
+	Vec4.fr(VX.fr(rgb), VY.fr(rgb), VZ.fr(rgb), 1.0);
 }).add;
 )
 
@@ -195,9 +195,9 @@ code::
 
 (
 ~zoom = ScinthDef.new(\zoom, {
-	var pos = NormPos.fg;
-	var box = 1.0 - max(VX.fg(pos).abs, VY.fg(pos).abs);
-	BWOut.fg(VSaw.fg(phase: box));
+	var pos = NormPos.fr;
+	var box = 1.0 - max(VX.fr(pos).abs, VY.fr(pos).abs);
+	BWOut.fr(VSaw.fr(phase: box));
 }).add;
 )
 

--- a/HelpSource/Guides/Scintillator-User-Guide.schelp
+++ b/HelpSource/Guides/Scintillator-User-Guide.schelp
@@ -95,14 +95,14 @@ image::empty-window.png::
 
 subsection::Time-Varying Video Synths
 
-The link::Classes/ScinOsc:: oscillator is similar to the similar class link::Classes/SinOsc::, with the soft emphasis::sc:: sound at the start intended to be a play on the name scintillator. There are some differences in a video synth from an audio one, however. The first consideration is that signals don't have to vary over time to impact the output. The first Scinth, code::\red::, should prove that. A similar constant output in an audio context would be inaudible, except for that it might damage certain audo setups, so caution is advised in testing that assertion!
+The link::Classes/VSinOsc:: oscillator is similar to the similar class link::Classes/SinOsc::, with the soft emphasis::sc:: sound at the start intended to be a play on the name scintillator. There are some differences in a video synth from an audio one, however. The first consideration is that signals don't have to vary over time to impact the output. The first Scinth, code::\red::, should prove that. A similar constant output in an audio context would be inaudible, except for that it might damage certain audo setups, so caution is advised in testing that assertion!
 
 Another point to note is that while audio signals normally operate in the domain from -1 to +1, with negative signals indicating a moment of underpressure in the sound wave, video signals only vary from 0 to 1. Light can only be present or absent in this video synthesizer, with 0 indicating no light and 1 indicating maximum brightness of light. Most video cards will clamp output between 0 and 1, but Scintillator doesn't take any special steps to limit signals, and video signals outside of the range are typically clamped. As a result of the different range, many of the default inputs on link::Classes/VGen::s with analogous link::Classes/UGen::s are  are adjusted so that instead of providing a signal input from -1 to +1 they output from 0 to 1. This can be seen, for example, in the defaults to link::Classes/SinOsc::, where the code::mul:: and code::add:: arguments are both code::0.5::, constraining the video signal between 0 and 1.
 
 code::
 (
 ~w = ScinthDef.new(\wave, { |f=1|
-	BWOut.fr(ScinOsc.fr(freq: f));
+	BWOut.fr(VSinOsc.fr(freq: f));
 }).add;
 )
 

--- a/HelpSource/Guides/VGens-Overview.schelp
+++ b/HelpSource/Guides/VGens-Overview.schelp
@@ -8,7 +8,7 @@ section::Video Oscillators
 There are only a few test oscillators implemented for now, with plans to add many more. One key conceptual difference between SuperCollider audio oscillators and Scintillator video oscillators to bear in mind is that video signals are constrained to values between code::[0, 1]::, unlike audio signals, which operate normally between code::[-1, 1]::.
 
 table::
-## link::Classes/ScinOsc::code::.fg(freq, phas, mul, add):: || table::
+## link::Classes/ScinOsc::code::.fr(freq, phas, mul, add):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 1
 ## 2, 2, 2, 2 || 2
@@ -16,7 +16,7 @@ table::
 ## 4, 4, 4, 4 || 4
 :: || Piecewise sinusodal oscillator, analogous to link::Classes/SinOsc::
 
-## link::Classes/VSaw::code::.fg(freq, phas, mul, add):: || table::
+## link::Classes/VSaw::code::.fr(freq, phas, mul, add):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 1
 ## 2, 2, 2, 2 || 2
@@ -30,17 +30,17 @@ section::Image Sampling
 VGens for reading from link::Classes/ImageBuffer:: objects.
 
 table::
-## link::Classes/Sampler::code::.fg(image, pos):: || table::
+## link::Classes/Sampler::code::.fr(image, pos):: || table::
 ## strong::input:: || strong::output::
 ## image, 2 || 4
 :: || Samples the provided imageBuffer at code::pos:: and returns the 4D color signal as code::(r, g, b, a)::
 
-## link::Classes/TexPos::code::.fg():: || table::
+## link::Classes/TexPos::code::.fr():: || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Texture Sampler position
 
-## link::Classes/TextureSize::code::.fg(image):: || table::
+## link::Classes/TextureSize::code::.fr(image):: || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Returns the dimensions in pixels of the provided ImageBuffer. Roughly analogous to link::Classes/BufFrames::.
@@ -51,17 +51,17 @@ section::Fragment Position
 Scintillator offers a few different means to determine the position of the current fragment shader relative to the geometry being rendered, or the onscreen pixel dimensions. The link::Classes/TexPos:: VGen is in the Image Sampling section.
 
 table::
-## link::Classes/NormPos::code::.fg():: || table::
+## link::Classes/NormPos::code::.fr():: || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Normalized fragment position
 
-## link::Classes/TexPos::code::.fg():: || table::
+## link::Classes/TexPos::code::.fr():: || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Texture Sampler position
 
-## link::Classes/FragCoord::code::.fg():: || table::
+## link::Classes/FragCoord::code::.fr():: || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Onscreen coordinates of current fragment in pixels
@@ -77,32 +77,32 @@ Some VGens require inputs that are higher-dimensional vectors. To construct thos
 
 table::
 ## strong::VGen:: || strong::dimensions:: || strong::description::
-## link::Classes/Vec2::code::.fg(x, y):: || table::
+## link::Classes/Vec2::code::.fr(x, y):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 2
 :: || Construct a 2D vector from individual elements code::x:: and code::y::
 
-## link::Classes/Vec3::code::.fg(x, y, z):: || table::
+## link::Classes/Vec3::code::.fr(x, y, z):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 3
 :: || Construct a 3D vector from individual elements code::x:: and code::y::
 
-## link::Classes/Vec4::code::.fg(x, y, z, w):: || table::
+## link::Classes/Vec4::code::.fr(x, y, z, w):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 4
 :: || Construct a 4D vector from individual elements code::x:: and code::y::
 
-## link::Classes/Splat2::code::.fg(x):: || table::
+## link::Classes/Splat2::code::.fr(x):: || table::
 ## strong::input:: || strong::output::
 ## 1 || 2
 :: || Construct a 2D vector from a single element copied into both
 
-## link::Classes/Splat3::code::.fg(x):: || table::
+## link::Classes/Splat3::code::.fr(x):: || table::
 ## strong::input:: || strong::output::
 ## 1 || 3
 :: || Construct a 3D vector from a single element copied into both
 
-## link::Classes/Splat4::code::.fg(x):: || table::
+## link::Classes/Splat4::code::.fr(x):: || table::
 ## strong::input:: || strong::output::
 ## 1 || 4
 :: || Construct a 4D vector from a single element copied into both
@@ -114,7 +114,7 @@ To break out a single-dimensional signal from a higher-dimensional vector, use t
 
 table::
 ## strong::VGen:: || strong::dimensions:: || strong::description::
-## link::Classes/VX::code::.fg(v):: || table::
+## link::Classes/VX::code::.fr(v):: || table::
 ## strong::input:: || strong::output::
 ## 1 || 1
 ## 2 || 1
@@ -122,20 +122,20 @@ table::
 ## 4 || 1
 :: || Return the first element in the vector.
 
-## link::Classes/VY::code::.fg(v):: || table::
+## link::Classes/VY::code::.fr(v):: || table::
 ## strong::input:: || strong::output::
 ## 2 || 1
 ## 3 || 1
 ## 4 || 1
 :: || Return the second element in the vector.
 
-## link::Classes/VZ::code::.fg(v):: || table::
+## link::Classes/VZ::code::.fr(v):: || table::
 ## strong::input:: || strong::output::
 ## 3 || 1
 ## 4 || 1
 :: || Return the third element in the vector.
 
-## link::Classes/VW::code::.fg(v):: || table::
+## link::Classes/VW::code::.fr(v):: || table::
 ## strong::input:: || strong::output::
 ## 4 || 1
 :: || Return the fourth element in the vector.
@@ -146,17 +146,17 @@ subsection::Video Output Convenience
 Any 4D output is considered valid link::Classes/ScinthDef:: output.
 
 table::
-## link::Classes/RGBOut::code::.fg(r, g, b):: || table::
+## link::Classes/RGBOut::code::.fr(r, g, b):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 4
 :: || Convenience object for color output at full alpha
 
-## link::Classes/RGBAOut::code::.fg(r, g, b):: || table::
+## link::Classes/RGBAOut::code::.fr(r, g, b):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 4
 :: || Convenience object for color output with alpha channel
 
-## link::Classes/BWOut::code::.fg(x):: || table::
+## link::Classes/BWOut::code::.fr(x):: || table::
 ## strong::input:: || strong::output::
 ## 1 || 4
 :: || Convenience object for black and white output at full alpha
@@ -170,7 +170,7 @@ subsection::Vector Operations
 
 table::
 ## strong::VGen:: || strong::dimensions:: || strong::description::
-## link::Classes/Clamp::code::.fg(x, min, max):: || table::
+## link::Classes/Clamp::code::.fr(x, min, max):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 1
 ## 2, 2, 2 || 2
@@ -178,7 +178,7 @@ table::
 ## 4, 4, 4 || 4
 :: || Video equivalent of link::Classes/Clip:: UGen, piecewise bounds input code::x:: between code::[min, max]::
 
-## link::Classes/Length::code::.fg(x):: || table::
+## link::Classes/Length::code::.fr(x):: || table::
 ## strong::input:: || strong::output::
 ## 1 || 1
 ## 2 || 1
@@ -186,14 +186,14 @@ table::
 ## 4 || 1
 :: || Returns the length of the vector code::x::, or the square root of the sum of the squares
 
-## link::Classes/Distance::code::.fg(x, y):: || table::
+## link::Classes/Distance::code::.fr(x, y):: || table::
 ## 1, 1 || 1
 ## 2, 2 || 1
 ## 3, 3 || 1
 ## 4, 4 || 1
 :: || Computes the distance between code::x:: and code::y::, which is the length of the vector code::x - y::
 
-## link::Classes/Step::code::.fg(step, x):: || table::
+## link::Classes/Step::code::.fr(step, x):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 1
 ## 2, 2 || 2
@@ -201,7 +201,7 @@ table::
 ## 4, 4 || 4
 :: || Just like the binary operator code::thresh::, returns code::0:: when code::x < step::, otherwise code::x::
 
-## link::Classes/VecMix::code::.fg(x, y, a):: || table::
+## link::Classes/VecMix::code::.fr(x, y, a):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 1
 ## 2, 2, 1 || 2
@@ -212,7 +212,7 @@ table::
 ## 4, 4, 4 || 4
 :: || Similar to the binary operator code::blend::, returns a linear mix of code::x, y:: with code::a:: between code::[0, 1]::. Supports piecewise comparison or a single blend argument to apply to all components
 
-## link::Classes/Dot::code::.fg(x, y):: || table::
+## link::Classes/Dot::code::.fr(x, y):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 1
 ## 2, 2 || 1
@@ -220,12 +220,12 @@ table::
 ## 4, 4 || 1
 :: || Returns the dot product between code::x:: and code::y::, or the sum of the product of each component in the vector
 
-## link::Classes/Cross::code::.fg(x, y):: || table::
+## link::Classes/Cross::code::.fr(x, y):: || table::
 ## strong::input:: || strong::output::
 ## 3, 3 || 3
 :: || Returns the cross product of code::x:: and code::y::
 
-## link::Classes/VNorm::code::.fg(x):: || table::
+## link::Classes/VNorm::code::.fr(x):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 1
 ## 2, 2 || 2
@@ -246,11 +246,11 @@ The following tables detail the current supported operations along with the ones
 All unary operations support inputs in 1-4 dimensions, and produce outputs of the same dimension. For higher-dimensional signals all operations happen emphasis::piecewise::, meaning the operator is applied to each component of the signal independently. For example if code::b = a.neg:: and both code::a:: and code::b:: are link::Classes/Vec4:: objects then:
 
 code::
-b = Vec4.fg(
-	VX.fg(a).neg,
-	VY.fg(a).neg,
-	VZ.fg(a).neg,
-	VW.fg(a).neg);
+b = Vec4.fr(
+	VX.fr(a).neg,
+	VY.fr(a).neg,
+	VZ.fr(a).neg,
+	VW.fr(a).neg);
 ::
 
 table::
@@ -315,11 +315,11 @@ subsection::Built-In Binary Operations
 Binary operations also happen emphasis::piecewise::, meaning that the binary operator is applied to each individual component separately. Conceptually if code::c = a * b:: and both code::a:: and code::b:: are link::Classes/Vec4::s then:
 
 code::
-c = Vec4.fg(
-	VX.fg(a) * VX.fg(b),
-	VY.fg(a) * VY.fg(b),
-	VZ.fg(a) * VZ.fg(b),
-	VW.fg(a) * VW.fg(b));
+c = Vec4.fr(
+	VX.fr(a) * VX.fr(b),
+	VY.fr(a) * VY.fr(b),
+	VZ.fr(a) * VZ.fr(b),
+	VW.fr(a) * VW.fr(b));
 ::
 
 table::

--- a/HelpSource/Guides/VGens-Overview.schelp
+++ b/HelpSource/Guides/VGens-Overview.schelp
@@ -8,7 +8,7 @@ section::Video Oscillators
 There are only a few test oscillators implemented for now, with plans to add many more. One key conceptual difference between SuperCollider audio oscillators and Scintillator video oscillators to bear in mind is that video signals are constrained to values between code::[0, 1]::, unlike audio signals, which operate normally between code::[-1, 1]::.
 
 table::
-## link::Classes/ScinOsc::code::.fr(freq, phas, mul, add):: || table::
+## link::Classes/VSinOsc::code::.fr(freq, phas, mul, add):: || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 1
 ## 2, 2, 2, 2 || 2

--- a/HelpSource/Reference/Scintillator-ScinthDef-File-Format.schelp
+++ b/HelpSource/Reference/Scintillator-ScinthDef-File-Format.schelp
@@ -109,7 +109,7 @@ We execute the following code:
 code::
 (
 ~k = ScinthDef.new(\foo, {
-	VOut.fr(0, ScinOsc.fr(200.0, 0.0, 0.9, 0.2));
+	VOut.fr(0, VSinOsc.fr(200.0, 0.0, 0.9, 0.2));
 });
 ~k.asYAML.postln;
 )
@@ -120,7 +120,7 @@ And ScinthDef produces the following:
 code::
 - name: foo
   vgens:
-    - className: ScinOsc
+    - className: VSinOsc
       rate: fragment
       inputs:
         - type: constant

--- a/HelpSource/Reference/Scintillator-ScinthDef-File-Format.schelp
+++ b/HelpSource/Reference/Scintillator-ScinthDef-File-Format.schelp
@@ -109,7 +109,7 @@ We execute the following code:
 code::
 (
 ~k = ScinthDef.new(\foo, {
-	VOut.fg(0, ScinOsc.fg(200.0, 0.0, 0.9, 0.2));
+	VOut.fr(0, ScinOsc.fr(200.0, 0.0, 0.9, 0.2));
 });
 ~k.asYAML.postln;
 )

--- a/classes/BuiltIn.sc
+++ b/classes/BuiltIn.sc
@@ -1,5 +1,5 @@
 Clamp : VGen {
-	*fg { |x, min, max|
+	*fr { |x, min, max|
 		^this.multiNew(\fragment, x, min, max);
 	}
 
@@ -14,7 +14,7 @@ Clamp : VGen {
 
 
 Cross : VGen {
-	*fg { |x, y|
+	*fr { |x, y|
 		^this.multiNew(\fragment, x, y);
 	}
 
@@ -28,7 +28,7 @@ Cross : VGen {
 }
 
 Dot : VGen {
-	*fg { |x, y|
+	*fr { |x, y|
 		^this.multiNew(\fragment, x, y);
 	}
 
@@ -42,7 +42,7 @@ Dot : VGen {
 }
 
 Distance : VGen {
-	*fg { |x, y|
+	*fr { |x, y|
 		^this.multiNew(\fragment, x, y);
 	}
 
@@ -56,7 +56,7 @@ Distance : VGen {
 }
 
 FragCoord : VGen {
-	*fg {
+	*fr {
 		^this.multiNew(\fragment);
 	}
 
@@ -70,7 +70,7 @@ FragCoord : VGen {
 }
 
 Length : VGen {
-	*fg { |vec|
+	*fr { |vec|
 		^this.multiNew(\fragment, vec);
 	}
 
@@ -84,7 +84,7 @@ Length : VGen {
 }
 
 Step : VGen {
-	*fg { |step, x|
+	*fr { |step, x|
 		^this.multiNew(\fragment, step, x);
 	}
 
@@ -98,7 +98,7 @@ Step : VGen {
 }
 
 VecMix : VGen {
-	*fg { |x, y, a|
+	*fr { |x, y, a|
 		^this.multiNew(\fragment, x, y, a);
 	}
 
@@ -112,7 +112,7 @@ VecMix : VGen {
 }
 
 VNorm : VGen {
-	*fg { |x|
+	*fr { |x|
 		^this.multiNew(\fragment, x);
 	}
 

--- a/classes/InOut.sc
+++ b/classes/InOut.sc
@@ -1,5 +1,5 @@
 RGBOut : VGen {
-	*fg { |r, g, b|
+	*fr { |r, g, b|
 		^this.multiNew(\fragment, r, g, b);
 	}
 
@@ -13,7 +13,7 @@ RGBOut : VGen {
 }
 
 BWOut : VGen {
-	*fg { |v|
+	*fr { |v|
 		^this.multiNew(\fragment, v);
 	}
 
@@ -27,7 +27,7 @@ BWOut : VGen {
 }
 
 RGBAOut : VGen {
-	*fg { |r, g, b, a|
+	*fr { |r, g, b, a|
 		^this.multiNew(\fragment, r, g, b, a);
 	}
 
@@ -44,7 +44,7 @@ VControl : MultiOutVGen {
 	var <>values;
 
 	// TODO: it is not accurate to call these fragment rate.
-	*fg { |values|
+	*fr { |values|
 		^this.multiNewList([\fragment] ++ values.asArray);
 	}
 

--- a/classes/Intrinsics.sc
+++ b/classes/Intrinsics.sc
@@ -1,5 +1,5 @@
 NormPos : VGen {
-	*fg {
+	*fr {
 		^this.multiNew(\fragment);
 	}
 
@@ -13,7 +13,7 @@ NormPos : VGen {
 }
 
 TexPos : VGen {
-	*fg {
+	*fr {
 		^this.multiNew(\fragment);
 	}
 

--- a/classes/Sampler.sc
+++ b/classes/Sampler.sc
@@ -17,7 +17,7 @@ Sampler : VGen {
 	// one of \transparentBlack, \black, \white, only used if addressMode is set to \clampToBorder.
 	var <>clampBorderColor = \transparentBlack;
 
-	*fg { |image, pos|
+	*fr { |image, pos|
 		^this.multiNew(\fragment, pos).prSetupImageInput(image);
 	}
 
@@ -55,7 +55,7 @@ Sampler : VGen {
 }
 
 TextureSize : Sampler {
-	*fg { |image|
+	*fr { |image|
 		^this.multiNew(\fragment).prSetupImageInput(image);
 	}
 

--- a/classes/ScinthDef.sc
+++ b/classes/ScinthDef.sc
@@ -36,7 +36,7 @@ ScinthDef {
 		}, {
 			controls = func.def.prototypeFrame.extend(controlNames.size);
 			controls = controls.collect({ |value| value ? 0.0 });
-			^VControl.fg(controls)
+			^VControl.fr(controls)
 		});
 	}
 

--- a/classes/VGen.sc
+++ b/classes/VGen.sc
@@ -134,7 +134,7 @@ VGen : AbstractFunction {
 
 	methodSelectorForRate {
 		^switch(rate)
-		{\fragment} { \fg }
+		{\fragment} { \fr }
 		{nil}
 	}
 }

--- a/classes/VOsc.sc
+++ b/classes/VOsc.sc
@@ -1,4 +1,4 @@
-ScinOsc : VGen {
+VSinOsc : VGen {
 	*fr { |freq = 1.0, phase = 0.0, mul = 0.5, add = 0.5|
 		^this.multiNew(\fragment, freq, phase, mul, add);
 	}

--- a/classes/VOsc.sc
+++ b/classes/VOsc.sc
@@ -1,5 +1,5 @@
 ScinOsc : VGen {
-	*fg { |freq = 1.0, phase = 0.0, mul = 0.5, add = 0.5|
+	*fr { |freq = 1.0, phase = 0.0, mul = 0.5, add = 0.5|
 		^this.multiNew(\fragment, freq, phase, mul, add);
 	}
 
@@ -13,7 +13,7 @@ ScinOsc : VGen {
 }
 
 VSaw : VGen {
-	*fg { |freq = 1.0, phase = 0.0|
+	*fr { |freq = 1.0, phase = 0.0|
 		^this.multiNew(\fragment, freq, phase);
 	}
 

--- a/classes/Vectors.sc
+++ b/classes/Vectors.sc
@@ -1,5 +1,5 @@
 Vec2 : VGen {
-	*fg { |x = 0.0, y = 0.0|
+	*fr { |x = 0.0, y = 0.0|
 		^this.multiNew(\fragment, x, y);
 	}
 
@@ -13,7 +13,7 @@ Vec2 : VGen {
 }
 
 Vec3 : VGen {
-	*fg { |x = 0.0, y = 0.0, z = 0.0|
+	*fr { |x = 0.0, y = 0.0, z = 0.0|
 		^this.multiNew(\fragment, x, y, z);
 	}
 
@@ -27,7 +27,7 @@ Vec3 : VGen {
 }
 
 Vec4 : VGen {
-	*fg { |x = 0.0, y = 0.0, z = 0.0, w = 0.0|
+	*fr { |x = 0.0, y = 0.0, z = 0.0, w = 0.0|
 		^this.multiNew(\fragment, x, y, z, w);
 	}
 
@@ -41,7 +41,7 @@ Vec4 : VGen {
 }
 
 VX : VGen {
-	*fg { |vec|
+	*fr { |vec|
 		^this.multiNew(\fragment, vec);
 	}
 
@@ -55,7 +55,7 @@ VX : VGen {
 }
 
 VY : VGen {
-	*fg { |vec|
+	*fr { |vec|
 		^this.multiNew(\fragment, vec);
 	}
 
@@ -69,7 +69,7 @@ VY : VGen {
 }
 
 VZ : VGen {
-	*fg { |vec|
+	*fr { |vec|
 		^this.multiNew(\fragment, vec);
 	}
 
@@ -84,7 +84,7 @@ VZ : VGen {
 
 
 VW : VGen {
-	*fg { |vec|
+	*fr { |vec|
 		^this.multiNew(\fragment, vec);
 	}
 
@@ -98,7 +98,7 @@ VW : VGen {
 }
 
 Splat2 : VGen {
-	*fg { |x|
+	*fr { |x|
 		^this.multiNew(\fragment, x);
 	}
 
@@ -112,7 +112,7 @@ Splat2 : VGen {
 }
 
 Splat3 : VGen {
-	*fg { |x|
+	*fr { |x|
 		^this.multiNew(\fragment, x);
 	}
 
@@ -126,7 +126,7 @@ Splat3 : VGen {
 }
 
 Splat4 : VGen {
-	*fg { |x|
+	*fr { |x|
 		^this.multiNew(\fragment, x);
 	}
 

--- a/tests/TestScinthDef.sc
+++ b/tests/TestScinthDef.sc
@@ -99,14 +99,14 @@ TestScinthDef : UnitTest {
 
 	test_inputChainLinearBuild {
 		var def = ScinthDef.new(\inputChainLinearBuild, {
-			BWOut.fr(ScinOsc.fr.abs);
+			BWOut.fr(VSinOsc.fr.abs);
 		});
 
 		this.sanityCheckBuild(def);
 
 		this.assertEquals(def.name, \inputChainLinearBuild);
 		this.assertEquals(def.children.size, 3);
-		this.assertEquals(def.children[0].class, ScinOsc);
+		this.assertEquals(def.children[0].class, VSinOsc);
 		this.assertEquals(def.children[1].class, UnaryOpVGen);
 		this.assertEquals(def.children[1].name, 'VAbs');
 		this.assertEquals(def.children[1].inputs[0], def.children[0]);
@@ -127,7 +127,7 @@ TestScinthDef : UnitTest {
 	test_inputChainYaml {
 		var def = ScinthDef.new(\inputChainYaml, {
 			var pos = NormPos.fr;
-			BWOut.fr(ScinOsc.fr(freq: VY.fr(pos).neg, phase: VX.fr(pos), mul: 0.2, add: 0.5));
+			BWOut.fr(VSinOsc.fr(freq: VY.fr(pos).neg, phase: VX.fr(pos), mul: 0.2, add: 0.5));
 		});
 		var yaml = def.asYAML;
 

--- a/tests/TestScinthDef.sc
+++ b/tests/TestScinthDef.sc
@@ -83,7 +83,7 @@ TestScinthDef : UnitTest {
 
 	test_singleVgenBuild {
 		var def = ScinthDef.new(\singleVgenBuild, {
-			BWOut.fg(1.0);
+			BWOut.fr(1.0);
 		});
 
 		this.sanityCheckBuild(def);
@@ -99,7 +99,7 @@ TestScinthDef : UnitTest {
 
 	test_inputChainLinearBuild {
 		var def = ScinthDef.new(\inputChainLinearBuild, {
-			BWOut.fg(ScinOsc.fg.abs);
+			BWOut.fr(ScinOsc.fr.abs);
 		});
 
 		this.sanityCheckBuild(def);
@@ -116,7 +116,7 @@ TestScinthDef : UnitTest {
 
 	test_singleVgenYaml {
 		var def = ScinthDef.new(\singleVgenYaml, {
-			BWOut.fg(1.0.neg);
+			BWOut.fr(1.0.neg);
 		});
 		var yaml = def.asYAML;
 
@@ -126,8 +126,8 @@ TestScinthDef : UnitTest {
 
 	test_inputChainYaml {
 		var def = ScinthDef.new(\inputChainYaml, {
-			var pos = NormPos.fg;
-			BWOut.fg(ScinOsc.fg(freq: VY.fg(pos).neg, phase: VX.fg(pos), mul: 0.2, add: 0.5));
+			var pos = NormPos.fr;
+			BWOut.fr(ScinOsc.fr(freq: VY.fr(pos).neg, phase: VX.fr(pos), mul: 0.2, add: 0.5));
 		});
 		var yaml = def.asYAML;
 
@@ -137,8 +137,8 @@ TestScinthDef : UnitTest {
 
 	test_paramsNoValues {
 		var def = ScinthDef.new(\paramsNoValues, { |a, b, c|
-			var sin3 = Vec3.fg(a, b, c).sin;
-			RGBOut.fg(VX.fg(sin3), VY.fg(sin3), VZ.fg(sin3));
+			var sin3 = Vec3.fr(a, b, c).sin;
+			RGBOut.fr(VX.fr(sin3), VY.fr(sin3), VZ.fr(sin3));
 		});
 		// Make sure names are in correct order and all represented.
 		this.assertEquals(3, def.controlNames.size);
@@ -158,7 +158,7 @@ TestScinthDef : UnitTest {
 	test_paramsMixedValues {
 		var def = ScinthDef.new(\paramsValues, { |quick = 10.0, slow = 0.001, x = -17|
 			var average = quick + slow / 2;
-			BWOut.fg(average - x);
+			BWOut.fr(average - x);
 		});
 		this.assertEquals(3, def.controlNames.size);
 		this.assertEquals('quick', def.controlNames[0]);
@@ -179,7 +179,7 @@ TestScinthDef : UnitTest {
 
 		try {
 			ScinthDef(\vgen_nilIsInvalid, {
-				BWOut.fg(nil);
+				BWOut.fr(nil);
 			});
 		} { | e |
 			err = e;
@@ -195,7 +195,7 @@ TestScinthDef : UnitTest {
 
 		try {
 			ScinthDef(\vgen_nilIsInvalid, {
-				BWOut.fg(SinOsc.ar());
+				BWOut.fr(SinOsc.ar());
 			});
 		} { | e |
 			err = e;

--- a/tools/TestScripts/oscTest.scd
+++ b/tools/TestScripts/oscTest.scd
@@ -284,7 +284,7 @@ fork {
 	c.test = false;
 	d.test = false;
 	valid = false;
-	testDef = ScinthDef.new(\t, { BWOut.fg(1.0); });
+	testDef = ScinthDef.new(\t, { BWOut.fr(1.0); });
 	response = OSCFunc.new({ |msg|
 		c.test = true;
 		c.signal;

--- a/tools/TestScripts/testDefs/t1-2.yaml
+++ b/tools/TestScripts/testDefs/t1-2.yaml
@@ -42,7 +42,7 @@ vgens:
           dimension: 1
       outputs:
         - dimension: 1
-    - className: ScinOsc
+    - className: VSinOsc
       rate: fragment
       inputs:
         - type: vgen

--- a/tools/TestScripts/testManifest.yaml
+++ b/tools/TestScripts/testManifest.yaml
@@ -4,11 +4,11 @@
   shortName: "firstFrame"
   scinthDef: ""
   captureTimes: [ 1 ]
-- name: "ScinOsc Bullseye"
+- name: "VSinOsc Bullseye"
   category: "VOsc"
-  comment: "ScinOsc frequency as a function of distance from center."
+  comment: "VSinOsc frequency as a function of distance from center."
   shortName: "scinOsc"
-  scinthDef: "{ BWOut.fg(ScinOsc.fg(Length.fg(NormPos.fg))); }"
+  scinthDef: "{ BWOut.fg(VSinOsc.fg(Length.fg(NormPos.fg))); }"
   captureTimes: [ 1, 1, 1, 1, 1 ]
 - name: "VSaw Checker"
   category: "VOsc"

--- a/tools/TestScripts/testManifest.yaml
+++ b/tools/TestScripts/testManifest.yaml
@@ -8,15 +8,15 @@
   category: "VOsc"
   comment: "VSinOsc frequency as a function of distance from center."
   shortName: "scinOsc"
-  scinthDef: "{ BWOut.fg(VSinOsc.fg(Length.fg(NormPos.fg))); }"
+  scinthDef: "{ BWOut.fr(VSinOsc.fr(Length.fr(NormPos.fr))); }"
   captureTimes: [ 1, 1, 1, 1, 1 ]
 - name: "VSaw Checker"
   category: "VOsc"
   comment: "VSaw two color checker pattern."
   shortName: "gingham"
   scinthDef: "{
-    var pos = NormPos.fg;
-    RGBOut.fg(VSaw.fg(1.0, VX.fg(pos)), VSaw.fg(1.5, VY.fg(pos)), VSaw.fg(VX.fg(NormPos.fg)));
+    var pos = NormPos.fr;
+    RGBOut.fr(VSaw.fr(1.0, VX.fr(pos)), VSaw.fr(1.5, VY.fr(pos)), VSaw.fr(VX.fr(NormPos.fr)));
   }"
   captureTimes: [ 1, 1 ]
 - name: "Param Colors"
@@ -24,7 +24,7 @@
   comment: "Test default values of parameters and a simple change"
   shortName: "paramColors"
   scinthDef: "{ |r = 0.5, g = 0.1, b = 0.9|
-    RGBOut.fg(r, g, b);
+    RGBOut.fr(r, g, b);
   }"
   captureTimes: [ 1, 1, 1 ]
   parameters:
@@ -37,10 +37,10 @@
   comment: "Test parameters on a more complex ScinthDef"
   shortName: "paramParab"
   scinthDef: "{ |scale=2.0, xmod=0.5, ymod=0.5|
-    var pos = NormPos.fg() * scale;
-    var sawA = VSaw.fg(0.7, (VX.fg(pos) % xmod) * VY.fg(pos));
-    var sawB = VSaw.fg(0.9, VX.fg(pos) * (VY.fg(pos) % ymod));
-    BWOut.fg(sawA * sawB);
+    var pos = NormPos.fr() * scale;
+    var sawA = VSaw.fr(0.7, (VX.fr(pos) % xmod) * VY.fr(pos));
+    var sawB = VSaw.fr(0.9, VX.fr(pos) * (VY.fr(pos) % ymod));
+    BWOut.fr(sawA * sawB);
   }"
   captureTimes: [ 1, 1, 1 ]
   parameters:
@@ -54,11 +54,11 @@
   comment: "Test simple image render with constant image"
   shortName: "constImage"
   scinthDef: "{
-    var size = TextureSize.fg(1);
-    var aspect = VX.fg(size) / VY.fg(size);
-    var pos = TexPos.fg;
-    pos = Vec2.fg((VX.fg(pos) - 0.125) / aspect, VY.fg(pos));
-    Sampler.fg(1, pos); }"
+    var size = TextureSize.fr(1);
+    var aspect = VX.fr(size) / VY.fr(size);
+    var pos = TexPos.fr;
+    pos = Vec2.fr((VX.fr(pos) - 0.125) / aspect, VY.fr(pos));
+    Sampler.fr(1, pos); }"
   images:
     - file: "molly.png"
       number: 1
@@ -68,11 +68,11 @@
   comment: "Test simple image render with parameterized image"
   shortName: "paramImage"
   scinthDef: "{ |i|
-    var size = TextureSize.fg(i);
-    var aspect = VX.fg(size) / VY.fg(size);
-    var pos = TexPos.fg;
-    pos = Vec2.fg((VX.fg(pos) - 0.125) / aspect, VY.fg(pos));
-    Sampler.fg(i, pos);
+    var size = TextureSize.fr(i);
+    var aspect = VX.fr(size) / VY.fr(size);
+    var pos = TexPos.fr;
+    pos = Vec2.fr((VX.fr(pos) - 0.125) / aspect, VY.fr(pos));
+    Sampler.fr(i, pos);
   }"
   images:
     - file: "storm.png"
@@ -89,7 +89,7 @@
   category: "images"
   comment: "Test sampler border mode clamp with a white border"
   shortName: "whiteBorder"
-  scinthDef: "{ Sampler.fg(1, TexPos.fg * 3.0).clampBorderColor_('white'); }"
+  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).clampBorderColor_('white'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -98,7 +98,7 @@
   category: "images"
   comment: "Test sampler with border mode clamp with an opaque black border"
   shortName: "blackBorder"
-  scinthDef: "{ Sampler.fg(1, TexPos.fg * 3.0).clampBorderColor_('black'); }"
+  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).clampBorderColor_('black'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -107,7 +107,7 @@
   category: "images"
   comment: "Test sampler with clamp to edge border mode"
   shortName: "edgeBorder"
-  scinthDef: "{ Sampler.fg(1, TexPos.fg * 3.0).addressMode('clampToEdge'); }"
+  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).addressMode('clampToEdge'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -116,7 +116,7 @@
   category: "images"
   comment: "Test sampler with repeat border mode"
   shortName: "repeatBorder"
-  scinthDef: "{ Sampler.fg(1, TexPos.fg * 3.0).addressMode('repeat'); }"
+  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).addressMode('repeat'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -125,7 +125,7 @@
   category: "images"
   comment: "Test sampler with repeat border mode"
   shortName: "mirrorBorder"
-  scinthDef: "{ Sampler.fg(1, TexPos.fg * 3.0).addressMode('mirroredRepeat'); }"
+  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).addressMode('mirroredRepeat'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -135,9 +135,9 @@
   comment: "Test providing all forms of parameters to an Scinth"
   shortName: "complexImage"
   scinthDef: "{ |i = 2|
-    var pos = TexPos.fg;
-    var m = Sampler.fg(1, Vec2.fg(VSaw.fg(freq: 0.5, phase: VX.fg(pos)), VSaw.fg(freq: (0.75 / 2.0), phase: VY.fg(pos))));
-    var s = Sampler.fg(i, Vec2.fg(VSaw.fg(freq: 2.0, phase: 1.0 - VX.fg(pos)), VSaw.fg(freq: 1.5, phase: 1.0 - VY.fg(pos))) * 2.0);
+    var pos = TexPos.fr;
+    var m = Sampler.fr(1, Vec2.fr(VSaw.fr(freq: 0.5, phase: VX.fr(pos)), VSaw.fr(freq: (0.75 / 2.0), phase: VY.fr(pos))));
+    var s = Sampler.fr(i, Vec2.fr(VSaw.fr(freq: 2.0, phase: 1.0 - VX.fr(pos)), VSaw.fr(freq: 1.5, phase: 1.0 - VY.fr(pos))) * 2.0);
     s + m;
   }"
   images:
@@ -156,7 +156,7 @@
   comment: "Test alpha blending colors between different Scinths, starting with a white opaque background."
   shortName: "alphaWhite"
   scinthDef: "{
-    BWOut.fg(1.0);
+    BWOut.fr(1.0);
   }"
   captureTimes: [ 1 ]
   keep: true
@@ -165,9 +165,9 @@
   comment: "Add in a green alpha-blended offset circle."
   shortName: "alphaGreen"
   scinthDef: "{
-    var off = Vec2.fg(-0.3, 0.3);
-    var v = Clamp.fg(1.1 - (Length.fg(NormPos.fg - off)), 0.0, 1.0);
-    RGBAOut.fg(0, v, 0, v);
+    var off = Vec2.fr(-0.3, 0.3);
+    var v = Clamp.fr(1.1 - (Length.fr(NormPos.fr - off)), 0.0, 1.0);
+    RGBAOut.fr(0, v, 0, v);
   }"
   captureTimes: [ 1 ]
   keep: true
@@ -176,9 +176,9 @@
   comment: "Now add in a red layer. Note that the generated image is order-dependent."
   shortName: "alphaRed"
   scinthDef: "{
-    var off = Vec2.fg(0.3, 0.3);
-    var v = Clamp.fg(1.1 - (Length.fg(NormPos.fg - off)), 0.0, 1.0);
-    RGBAOut.fg(v, 0, 0, v);
+    var off = Vec2.fr(0.3, 0.3);
+    var v = Clamp.fr(1.1 - (Length.fr(NormPos.fr - off)), 0.0, 1.0);
+    RGBAOut.fr(v, 0, 0, v);
   }"
   captureTimes: [ 1 ]
   keep: true
@@ -187,9 +187,9 @@
   comment: "Add in a blue layer to complete the color wheel."
   shortName: "alphaBlue"
   scinthDef: "{
-    var off = Vec2.fg(0.0, -1.0 * Length.fg(0.3, 0.3));
-    var v = Clamp.fg(1.1 - (Length.fg(NormPos.fg - off)), 0.0, 1.0);
-    RGBAOut.fg(0, 0, v, v);
+    var off = Vec2.fr(0.0, -1.0 * Length.fr(0.3, 0.3));
+    var v = Clamp.fr(1.1 - (Length.fr(NormPos.fr - off)), 0.0, 1.0);
+    RGBAOut.fr(0, 0, v, v);
   }"
   captureTimes: [ 1 ]
   keep: true

--- a/tools/scintillatorLogo.scd
+++ b/tools/scintillatorLogo.scd
@@ -32,33 +32,33 @@
 */
 (
 ~logoDefBlue = ScinthDef.new(\scintillatorLogoBlue, { |freq = 7.0|
-	var pos = NormPos.fg;
-	var blue = (1.0 - ((Length.fg(pos) / 2).min(1.0))) * Vec4.fg(0.031, 0.486, 0.729);
-	blue = blue + Vec4.fg(0.0, 0.0, 0.0, 1.0);
+	var pos = NormPos.fr;
+	var blue = (1.0 - ((Length.fr(pos) / 2).min(1.0))) * Vec4.fr(0.031, 0.486, 0.729);
+	blue = blue + Vec4.fr(0.0, 0.0, 0.0, 1.0);
 	blue;
 });
 ~logoDefRed = ScinthDef.new(\scintillatorLogoRed, { |freq = 7.0|
-	var pos = NormPos.fg;
-	var x = VX.fg(pos);
-	var y = VY.fg(pos);
+	var pos = NormPos.fr;
+	var x = VX.fr(pos);
+	var y = VY.fr(pos);
 	var dim = x.abs.max(y.abs);
-	var vDim = Vec2.fg(dim, dim);
-	var square = Step.fg((Length.fg(vDim * freq).sin / 2) + 0.5, 0.5);
-	var red = square * Vec4.fg(1.0, 0.224, 0.0);
-	red = red + Vec4.fg(0.0, 0.0, 0.0, Step.fg(0.1, square));
+	var vDim = Vec2.fr(dim, dim);
+	var square = Step.fr((Length.fr(vDim * freq).sin / 2) + 0.5, 0.5);
+	var red = square * Vec4.fr(1.0, 0.224, 0.0);
+	red = red + Vec4.fr(0.0, 0.0, 0.0, Step.fr(0.1, square));
 	red;
 });
 ~logoDefGreen = ScinthDef.new(\scintillatorLogoGreen, { |freq = 7.0|
-	var pos = NormPos.fg;
-	var x = VX.fg(pos);
-	var y = VY.fg(pos);
+	var pos = NormPos.fr;
+	var x = VX.fr(pos);
+	var y = VY.fr(pos);
 	var rotx = (x - y) / 2.sqrt;
 	var roty = (x + y) / 2.sqrt;
 	var rotDim = rotx.abs.max(roty.abs);
-	var rotVdim = Vec2.fg(rotDim, rotDim);
-	var rotSquare = Step.fg((Length.fg(rotVdim * (freq * 2.sqrt)).sin / 2) + 0.5, 0.5);
-	var green = rotSquare * Vec4.fg(0.482, 0.929, 0.0);
-	green = green + Vec4.fg(0.0, 0.0, 0.0, Step.fg(0.1, rotSquare));
+	var rotVdim = Vec2.fr(rotDim, rotDim);
+	var rotSquare = Step.fr((Length.fr(rotVdim * (freq * 2.sqrt)).sin / 2) + 0.5, 0.5);
+	var green = rotSquare * Vec4.fr(0.482, 0.929, 0.0);
+	green = green + Vec4.fr(0.0, 0.0, 0.0, Step.fr(0.1, rotSquare));
 	green;
 });
 )

--- a/vgens/VOsc.yaml
+++ b/vgens/VOsc.yaml
@@ -1,21 +1,3 @@
-name: ScinOsc
-inputs:
-    - freq
-    - phase
-    - mul
-    - add
-outputs:
-    - out
-dimensions:
-    - inputs: 1
-      outputs: 1
-    - inputs: 2
-      outputs: 2
-    - inputs: 3
-      outputs: 3
-    - inputs: 4
-      outputs: 4
-shader: "@out = @add + (@mul * sin((@time * @freq * 2.0f * @pi) + @phase));"
 ---
 name: VSaw
 inputs:
@@ -33,4 +15,22 @@ dimensions:
     - inputs: 4
       outputs: 4
 shader: "@out = fract((@time + @phase) * @freq);"
-
+---
+name: VSinOsc
+inputs:
+    - freq
+    - phase
+    - mul
+    - add
+outputs:
+    - out
+dimensions:
+    - inputs: 1
+      outputs: 1
+    - inputs: 2
+      outputs: 2
+    - inputs: 3
+      outputs: 3
+    - inputs: 4
+      outputs: 4
+shader: "@out = @add + (@mul * sin((@time * @freq * 2.0f * @pi) + @phase));"


### PR DESCRIPTION
## Purpose and motivation

Based on feedback in #90. Agree that a rate-name method is more clear as .fr than as .fg. Also renames ScinOsc to VSinOsc for clarity and consistency.

## Implementation

Automated find/replace work using sed.

## Types of changes

* Enhancement

## Status

- [x] This PR is ready for review
