### PR TITLE
Adds windows compilation to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,20 @@ language: cpp
 
 matrix:
     include:
-        - os: linux
-          dist: bionic
-          compiler: clang
-          env:
-              - CC=clang-8 CXX=clang++-8
-              - DO_COVERAGE=true
-        - os: linux
-          dist: bionic
-          env:
-              - DO_COVERAGE=false
-        - os: osx
-          osx_image: xcode11
-          env:
-              - DO_COVERAGE=false
+#        - os: linux
+#          dist: bionic
+#          compiler: clang
+#          env:
+#              - CC=clang-8 CXX=clang++-8
+#              - DO_COVERAGE=true
+#        - os: linux
+#          dist: bionic
+#          env:
+#              - DO_COVERAGE=false
+#        - os: osx
+#          osx_image: xcode11
+#          env:
+#              - DO_COVERAGE=false
         - os: windows
 
 cache: ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
           osx_image: xcode11
           env:
               - DO_COVERAGE=false
+        - os: windows
 
 cache: ccache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,24 @@ language: cpp
 
 matrix:
     include:
-#        - os: linux
-#          dist: bionic
-#          compiler: clang
-#          env:
-#              - CC=clang-8 CXX=clang++-8
-#              - DO_COVERAGE=true
-#        - os: linux
-#          dist: bionic
-#          env:
-#              - DO_COVERAGE=false
-#        - os: osx
-#          osx_image: xcode11
-#          env:
-#              - DO_COVERAGE=false
+        - os: linux
+          dist: bionic
+          compiler: clang
+          cache: ccache
+          env:
+              - CC=clang-8 CXX=clang++-8
+              - DO_COVERAGE=true
+        - os: linux
+          dist: bionic
+          ccache: ccache
+          env:
+              - DO_COVERAGE=false
+        - os: osx
+          osx_image: xcode11
+          ccache: ccache
+          env:
+              - DO_COVERAGE=false
         - os: windows
-
-#cache: ccache
 
 before_install:
     - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 #              - DO_COVERAGE=false
         - os: windows
 
-cache: ccache
+#cache: ccache
 
 before_install:
     - $TRAVIS_BUILD_DIR/.travis/before-install-$TRAVIS_OS_NAME.sh

--- a/.travis/before-deploy-windows.sh
+++ b/.travis/before-deploy-windows.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -z $TRAVIS_TAG ]]; then
+    mkdir -p $HOME/builds/scinsynth-w64
+    powershell "compress-archive $TRAVIS_BUILD_DIR/bin/scinsynth-w64 $HOME/builds/scinsynth-w64-$TRAVIS_COMMIT.zip"
+    certutil -hashfile $HOME/builds/scinsynth-w64-$TRAVIS_COMMIT.zip SHA256 | sed -n '2,2p;2q' > $HOME/builds/scinsynth-w64-$TRAVIS_COMMIT.zip.sha256
+    export S3_URL='http://scintillator-synth-coverage.s3-website-us-west-1.amazonaws.com/builds/scinsynth-w64-'$TRAVIS_COMMIT'.zip'
+    export FWD_HTML='<html><head><meta http-equiv="refresh" content="0; url='$S3_URL'" /></head></html>'
+    echo $FWD_HTML > $HOME/builds/scinsynth-latest-x86_64.AppImage.html
+else
+    mkdir -p $HOME/releases/$TRAVIS_TAG
+    powershell "compress-archive $TRAVIS_BUILD_DIR/bin/scinsynth-w64 $HOME/releases/$TRAVIS_TAG/scinsynth-w64.zip"
+    certutil -hashfile $HOME/releases/$TRAVIS_TAG/scinsynth-w64.zip SHA256 | sed -n '2,2p;2q' > $HOME/releases/$TRAVIS_TAG/scinsynth-w64.zip.sha256
+fi

--- a/.travis/before-install-windows.sh
+++ b/.travis/before-install-windows.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-choco install python3 doxygen.install gperf
+choco install python3 gperf

--- a/.travis/before-install-windows.sh
+++ b/.travis/before-install-windows.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+choco install python3 doxygen.install gperf

--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -2,6 +2,6 @@
 
 cd $TRAVIS_BUILD_DIR/build
 
-cmake -G Xcode -DPYTHON_EXECUTABLE=`which python3` -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13                                 \
+cmake -G Xcode -DPYTHON_EXECUTABLE=`which python3` -DSCIN_BUILD_DOCS=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13           \
     -DSCIN_SCLANG=$TRAVIS_HOME/sclang/SuperCollider/SuperCollider.app/Contents/MacOS/sclang ..
 

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # cmake -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
-cd $TRAVIS_BUILD_DIR/build
+cd $TRAVIS_BUILD_DIR
 python tools/fetch-binary-deps
 cd $TRAVIS_BUILD_DIR/build
 cmake -DSCIN_BUILD_DOCS=OFF ..

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 # cmake -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
+mkdir $TRAVIS_BUILD_DIR/build
+cd $TRAVIS_BUILD_DIR/build
 cmake ..
 

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -3,5 +3,5 @@
 cd $TRAVIS_BUILD_DIR
 /c/Python38/python.exe tools/fetch-binary-deps.py
 cd $TRAVIS_BUILD_DIR/build
-cmake -DSCIN_BUILD_DOCS=OFF -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
+cmake -DSCIN_BUILD_DOCS=OFF -DPYTHON_EXECUTABLE=/c/Python38/python.exe -DCMAKE_GENERATOR_PLATFORM=x64 ..
 

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # cmake -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
-mkdir $TRAVIS_BUILD_DIR/build
 cd $TRAVIS_BUILD_DIR/build
-cmake ..
+python tools/fetch-binary-deps
+cd $TRAVIS_BUILD_DIR/build
+cmake -DSCIN_BUILD_DOCS=OFF ..
 

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# cmake -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
 cd $TRAVIS_BUILD_DIR
-python tools/fetch-binary-deps.py
+/c/Python38/python.exe tools/fetch-binary-deps.py
 cd $TRAVIS_BUILD_DIR/build
-cmake -DSCIN_BUILD_DOCS=OFF ..
+cmake -DSCIN_BUILD_DOCS=OFF -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
 

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# cmake -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
+cmake ..
+

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -2,7 +2,7 @@
 
 # cmake -DPYTHON_EXECUTABLE=/c/Python38/python.exe ..
 cd $TRAVIS_BUILD_DIR
-python tools/fetch-binary-deps
+python tools/fetch-binary-deps.py
 cd $TRAVIS_BUILD_DIR/build
 cmake -DSCIN_BUILD_DOCS=OFF ..
 

--- a/.travis/script-windows.sh
+++ b/.travis/script-windows.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cmake --build . --config Release

--- a/.travis/script-windows.sh
+++ b/.travis/script-windows.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+cd $TRAVIS_BUILD_DIR/build
 cmake --build . --config Release


### PR DESCRIPTION
## Purpose and motivation

Continuing work on #11. Adds Windows compilation to Travis CI. Test image generation blocked by adding png encode support to ffmpeg (filed #111), so reserved for a future PR.

## Implementation

Travis shell scripting to add a windows build, configure the build machine with dependencies, and compile.

## Types of changes

* Enhancement

## Status

- [ ] This PR is ready for review
