### PR TITLE
cmake: fail early if gperf not found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,8 +17,13 @@ endif()
 #### "Core" files (without external dependencies)
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/base")
 
+find_program(gperf_program gperf)
+if (NOT gperf_program)
+    message(FATAL_ERROR "Could not find gperf")
+endif()
+
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/base/Intrinsic.cpp"
-    COMMAND gperf --output-file=${CMAKE_CURRENT_BINARY_DIR}/base/Intrinsic.cpp ${CMAKE_CURRENT_SOURCE_DIR}/base/Intrinsic.cpp.in
+    COMMAND ${gperf_program} --output-file=${CMAKE_CURRENT_BINARY_DIR}/base/Intrinsic.cpp ${CMAKE_CURRENT_SOURCE_DIR}/base/Intrinsic.cpp.in
     MAIN_DEPENDENCY base/Intrinsic.cpp.in
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/base"
     VERBATIM
@@ -91,7 +96,7 @@ endif()
 configure_file(infra/Version.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/infra/Version.hpp")
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/osc/commands")
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/osc/commands/Command.cpp"
-    COMMAND gperf --output-file=${CMAKE_CURRENT_BINARY_DIR}/osc/commands/Command.cpp ${CMAKE_CURRENT_SOURCE_DIR}/osc/commands/Command.cpp.in
+    COMMAND ${gperf_program} --output-file=${CMAKE_CURRENT_BINARY_DIR}/osc/commands/Command.cpp ${CMAKE_CURRENT_SOURCE_DIR}/osc/commands/Command.cpp.in
     MAIN_DEPENDENCY osc/commands/Command.cpp.in
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/osc/commands"
     VERBATIM


### PR DESCRIPTION
## Purpose and motivation

it's nice to know earlier on that gperf isn't available; this adds a simple CMake check and prints a fatal error if
gperf can't be found.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
- [x] Unit tests added - no unit tests, but i did confirm locally this has the desired effect
- [x] Unit tests are passing