### PR TITLE
fix compiler warnings

### DIFF
--- a/src/vulkan/Sampler.cpp
+++ b/src/vulkan/Sampler.cpp
@@ -16,6 +16,9 @@ VkFilter filterForAbstract(scin::base::AbstractSampler::FilterMode filterMode) {
     case scin::base::AbstractSampler::FilterMode::kNearest:
         return VK_FILTER_NEAREST;
     }
+
+    spdlog::error("Unknown FilterMode; defaulting to linear");
+    return VK_FILTER_LINEAR;
 }
 
 VkSamplerAddressMode addressModeForAbstract(scin::base::AbstractSampler::AddressMode addressMode) {
@@ -32,6 +35,9 @@ VkSamplerAddressMode addressModeForAbstract(scin::base::AbstractSampler::Address
     case scin::base::AbstractSampler::AddressMode::kMirroredRepeat:
         return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
     }
+
+    spdlog::error("Unknown AddressMode; defaulting to repeat");
+    return VK_SAMPLER_ADDRESS_MODE_REPEAT;
 }
 
 VkBorderColor borderColorForAbstract(scin::base::AbstractSampler::ClampBorderColor borderColor) {
@@ -45,6 +51,9 @@ VkBorderColor borderColorForAbstract(scin::base::AbstractSampler::ClampBorderCol
     case scin::base::AbstractSampler::ClampBorderColor::kWhite:
         return VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
     }
+
+    spdlog::error("Unknown ClampBorderColor; defaulting to transparent black");
+    return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
 }
 
 } // namespace


### PR DESCRIPTION
## Purpose and motivation

i wanted to eliminate the only warnings i was getting from within the project; there are also some within yamlcpp
that i don't know how to silence.

## Implementation

i'm not sure if this is how you'd like to handle this; if you don't ever expect these to be outside the enum values
then i was thinking maybe an assert might be more appropriate, but i didn't see any asserts in src/.

## Types of changes

* Enhancement

## Status

- [x] This PR is ready for review
- [x] Unit tests added
- [x] Unit tests are passing