### PR TITLE
Add Windows Install

### DIFF
--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -175,8 +175,6 @@ ScinServer {
 			commandLine = scinBinaryPath.shellQuote + options.asOptionsString();
 		});
 
-		commandLine.postln;
-
 		scinPid = commandLine.unixCmd({ |exitCode, exitPid|
 			if (exitCode == 0, {
 				"*** scinsynth exited normally.".postln;

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -266,7 +266,9 @@ ScinServerInstaller {
 									state = \checkIfBinaryExists;
 								},
 								\windows, {
-									continue = false;
+									"PowerShell Expand-Archive -Path % -DestinationPath %".format(
+										downloadPath, quarkBinPath).unixCmdGetStdOut.postln;
+                                    state = \checkIfBinaryExists;
 								}
 							);
 

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -1,5 +1,6 @@
 ScinServerInstaller {
 	const releasesURL = "https://scintillator-synth-coverage.s3-us-west-1.amazonaws.com/releases/";
+
 	classvar routine;
 	classvar continue;
 
@@ -276,12 +277,19 @@ ScinServerInstaller {
 					},
 
 					\moveOldBinary, {
+						var moveCmd = "mv";
+
+						Platform.case(\windows) {
+							moveCmd = "move";
+						};
+
 						if (oldVersion.isNil, {
 							"*** unable to determine version of old binary, using \"unknown\"".postln;
 							oldVersion = ".unknown";
 						});
 						oldBinPath = binaryPath ++ "." ++ oldVersion ++ ".bak";
-						"mv \"%\" \"%\"".format(binaryPath, oldBinPath).unixCmdGetStdOut;
+
+						"% \"%\" \"%\"".format(moveCmd, binaryPath, oldBinPath).unixCmdGetStdOut;
 						state = \extractBinary;
 					},
 				); // switch

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -68,8 +68,10 @@ ScinServerInstaller {
 								runtime = binaryPath;
 							},
 							\windows, {
-								"*** Windows not (yet) supported!".postln;
-								continue = false;
+								binaryPath = quarkBinPath +/+ "scinsynth-w64/scinsynth.exe";
+								downloadURL = releasesURL.replace("https", "http") ++ version ++ "/scinsynth-w64.zip";
+								downloadPath = quarkBinPath +/+ "scinsynth-w64." ++ version ++ ".zip";
+								runtime = binaryPath;
 							}
 						);
 

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -222,14 +222,21 @@ ScinServerInstaller {
 
 					\checkHash, {
 						// TODO: windows has a different command for hashing
-						var hashOutput = "shasum -a 256 -b \"%\"".format(downloadPath).unixCmdGetStdOut.split($ );
-						var targetHash = File.readAllString(downloadPath ++ ".sha256").split($ );
-						if (hashOutput[0] == targetHash[0], {
+						var hashOutput;
+						var targetHash = File.readAllString(downloadPath ++ ".sha256").split($ )[0];
+
+						Platform.case(\windows) {
+							hashOutput = "PowerShell (Get-FileHash -Path % -Algorithm SHA256).Hash".format(downloadPath).unixCmdGetStdOut.toLower;
+						} {
+							hashOutput = "shasum -a 256 -b \"%\"".format(downloadPath).unixCmdGetStdOut.split($ )[0];
+						};
+
+						if (hashOutput == targetHash, {
 							"downloaded file validated, extracting.".postln;
 							state = \extractBinary;
 						}, {
 							"*** hash mishmatch on downloaded file %. Expected '%', got '%'.".format(downloadPath,
-								targetHash[0], hashOutput[0]).postln;
+								targetHash, hashOutput).postln;
 							if (cleanup, {
 								"deleting bad hash file % and aborting. Please try again.".format(downloadPath).postln;
 								File.delete(downloadPath);

--- a/classes/ScinServerInstaller.sc
+++ b/classes/ScinServerInstaller.sc
@@ -222,7 +222,6 @@ ScinServerInstaller {
 					},
 
 					\checkHash, {
-						// TODO: windows has a different command for hashing
 						var hashOutput;
 						var targetHash = File.readAllString(downloadPath ++ ".sha256").split($ )[0];
 


### PR DESCRIPTION
## Purpose and motivation

<!-- Discuss why you made the PR and what it attempts to do -->

This PR adds Windows installation to the ScinServerInstaller.

## Implementation

<!-- Discuss how you made the PR and why it works that way -->

This PR adds the download, hash checking, and extraction of binaries for Windows.
Hash checking and extraction are handled by PowerShell commands.

Note that the `Download` class requires `http` on Windows. An upstream SC fix would be required for `https`.

There are also some minor refactors for the platform switching to make the code more readable (primarily the hash checking). Other platforms will need to be checked to ensure functionality remains the same.

## Types of changes

<!-- Delete as needed -->
* Behaviour change
* Enhancement

## Status

- [x] This PR is ready for review
