### PR TITLE
Adds realtime audio upload to texture on Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "third_party/fmt"]
 	path = third_party/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "third_party/portaudio"]
+	path = third_party/portaudio
+	url = https://git.assembla.com/portaudio.git

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -6,12 +6,34 @@ sudo add-apt-repository --yes ppa:supercollider/ppa
 sudo apt-get update
 
 # Install all the build and test dependencies
-sudo apt-get install --yes build-essential  cmake doxygen gperf imagemagick libwayland-dev libxcursor-dev libxi-dev    \
-    libxinerama-dev libxrandr-dev pkg-config python3-distutils python3-yaml supercollider-ide xvfb zlib1g
+sudo apt-get install --yes      \
+    build-essential             \
+    cmake                       \
+    doxygen                     \
+    gperf                       \
+    imagemagick                 \
+    libjack-jackd2-dev          \
+    libwayland-dev              \
+    libxcursor-dev              \
+    libxi-dev                   \
+    libxinerama-dev             \
+    libxrandr-dev               \
+    pkg-config                  \
+    python3-distutils           \
+    python3-yaml                \
+    supercollider-ide           \
+    xvfb                        \
+    zlib1g
 
 # Coverage and Linting requires clang-8
 if [ $DO_COVERAGE = true ]; then
-    sudo apt-get install --yes clang-8 clang-format-8 libc++-8-dev libc++abi-8-dev llvm-8-dev libc++abi-8-dev llvm-8-dev
+    sudo apt-get install --yes  \
+        clang-8                 \
+        clang-format-8          \
+        libc++-8-dev            \
+        libc++abi-8-dev         \
+        libc++abi-8-dev         \
+        llvm-8-dev              \
 fi
 
 cd $TRAVIS_BUILD_DIR

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -33,7 +33,7 @@ if [ $DO_COVERAGE = true ]; then
         libc++-8-dev            \
         libc++abi-8-dev         \
         libc++abi-8-dev         \
-        llvm-8-dev              \
+        llvm-8-dev
 fi
 
 cd $TRAVIS_BUILD_DIR

--- a/HelpSource/Reference/VGen-File-Format.schelp
+++ b/HelpSource/Reference/VGen-File-Format.schelp
@@ -53,10 +53,10 @@ subsection::@sampler
 
 In sampling VGens, represents the currently bound Vulkan sampler object and image within the shader.
 
-subsection::@time
-
-The VGen will receive a upated value every frame which contains the elapsed time in seconds from when the Scinth instance started. The time intrinsic is always 1 dimensional.
-
 subsection::@texPos
 
 Texture coordinates are typically constrained within [0, 1] inclusive, with Samplers configured to do different things outside of the texture coordinate region. The synth will configure a shape to include texture coordinate information with the vertex and fragment shaders if this intrinsic is present. Texture coordinates are currently always assumed to be 2 dimensional.
+
+subsection::@time
+
+The VGen will receive a upated value every frame which contains the elapsed time in seconds from when the Scinth instance started. The time intrinsic is always 1 dimensional.

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -31,6 +31,7 @@ ScinServerOptions {
 	var <>swiftshader;
 	var <>deviceName;
 	var <>vulkanValidation;
+	var <>audioInputChannels;
 
 	// Can install a function to call if server exits with a non-zero error code.
 	var <>onServerError;
@@ -50,7 +51,8 @@ ScinServerOptions {
 				alwaysOnTop: true,
 				swiftshader: false,
 				deviceName: nil,
-				vulkanValidation: false
+				vulkanValidation: false,
+				audioInputChannels: 0
 			)
 		);
 	}
@@ -105,6 +107,9 @@ ScinServerOptions {
 		});
 		if (vulkanValidation != defaultValues[\vulkanValidation], {
 			o = o + "--vulkanValidation";
+		});
+		if (audioInputChannels != defaultValues[\audioInputChannels], {
+			o = o + "--audioInputChannels=" ++ audioInputChannels;
 		});
 		^o;
 	}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -341,7 +341,7 @@ target_link_libraries(scinsynth
     gflags
     glfw
     glm
-    portaudio
+    portaudio_static
     scintillator_base
     spdlog
 )
@@ -386,9 +386,6 @@ if (APPLE)
     )
     install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/macos/Resources/vulkan"
         DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Resources"
-    )
-    install(TARGETS portaudio LIBRARY
-        DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Frameworks"
     )
     list(APPEND SCIN_MACOS_LIBS "${SCIN_EXT_INSTALL_DIR}/lib")
     list(APPEND SCIN_MACOS_LIBS "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Frameworks")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,6 +132,8 @@ set(scintillator_synth_files
 
     comp/Async.cpp
     comp/Async.hpp
+    comp/AudioStager.cpp
+    comp/AudioStager.hpp
     comp/Canvas.cpp
     comp/Canvas.hpp
     comp/Compositor.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,8 @@ set(scintillator_synth_files
     "${CMAKE_CURRENT_BINARY_DIR}/osc/commands/Command.cpp"
     scinsynth.cpp
 
+    audio/Ingress.cpp
+    audio/Ingress.hpp
     audio/PortAudio.cpp
     audio/PortAudio.hpp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,7 +387,11 @@ if (APPLE)
     install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/macos/Resources/vulkan"
         DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Resources"
     )
+    install(TARGETS portaudio LIBRARY
+        DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Frameworks"
+    )
     list(APPEND SCIN_MACOS_LIBS "${SCIN_EXT_INSTALL_DIR}/lib")
+    list(APPEND SCIN_MACOS_LIBS "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Frameworks")
     install(CODE "
         include(BundleUtilities)
         fixup_bundle(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,9 @@ set(scintillator_synth_files
     "${CMAKE_CURRENT_BINARY_DIR}/osc/commands/Command.cpp"
     scinsynth.cpp
 
+    audio/PortAudio.cpp
+    audio/PortAudio.hpp
+
     av/AVIncludes.hpp
     av/Buffer.cpp
     av/Buffer.hpp
@@ -336,6 +339,7 @@ target_link_libraries(scinsynth
     gflags
     glfw
     glm
+    portaudio
     scintillator_base
     spdlog
 )

--- a/src/audio/Ingress.cpp
+++ b/src/audio/Ingress.cpp
@@ -7,13 +7,13 @@ namespace scin { namespace audio {
 
 const int kSamplesPerChannel = 8192;
 
-Ingress::Ingress(int channels): m_channels(channels), m_ringBuffer(new PaUtilRingBuffer),
-    m_buffer(new float[kSamplesPerChannel * channels]) {
-}
+Ingress::Ingress(int channels, int sampleRate):
+    m_channels(channels),
+    m_sampleRate(sampleRate),
+    m_ringBuffer(new PaUtilRingBuffer),
+    m_buffer(new float[kSamplesPerChannel * channels]) { }
 
-Ingress::~Ingress() {
-
-}
+Ingress::~Ingress() { }
 
 bool Ingress::create() {
     ring_buffer_size_t size = PaUtil_InitializeRingBuffer(m_ringBuffer.get(), 4, kSamplesPerChannel * m_channels,
@@ -34,6 +34,19 @@ void Ingress::ingestSamples(const float* input, unsigned long frameCount) {
     // TODO: logging on buffer oflow, maybe atomically increment a counter?
     unsigned long elementCount = std::min(frameCount * m_channels, writeAvailable);
     unsigned long framesWritten = PaUtil_WriteRingBuffer(m_ringBuffer.get(), input, elementCount);
+}
+
+unsigned long Ingress::availableFrames() {
+    return PaUtil_GetRingBufferReadAvailable(m_ringBuffer.get()) / m_channels;
+}
+
+void Ingress::dropSamples(unsigned long frameCount) {
+    PaUtil_AdvanceRingBufferReadIndex(m_ringBuffer.get(), frameCount * m_channels);
+}
+
+unsigned long Ingress::extractSamples(float* output, unsigned long frameCount) {
+    auto readSamples = std::min(availableFrames(), frameCount) * m_channels;
+    return PaUtil_ReadRingBuffer(m_ringBuffer.get(), output, readSamples);
 }
 
 } // namespace audio

--- a/src/audio/Ingress.cpp
+++ b/src/audio/Ingress.cpp
@@ -11,13 +11,13 @@ Ingress::Ingress(int channels, int sampleRate):
     m_channels(channels),
     m_sampleRate(sampleRate),
     m_ringBuffer(new PaUtilRingBuffer),
-    m_buffer(new float[kSamplesPerChannel * channels]) { }
+    m_buffer(new float[kSamplesPerChannel * channels]) {}
 
-Ingress::~Ingress() { }
+Ingress::~Ingress() {}
 
 bool Ingress::create() {
-    ring_buffer_size_t size = PaUtil_InitializeRingBuffer(m_ringBuffer.get(), 4, kSamplesPerChannel * m_channels,
-        m_buffer.get());
+    ring_buffer_size_t size =
+        PaUtil_InitializeRingBuffer(m_ringBuffer.get(), 4, kSamplesPerChannel * m_channels, m_buffer.get());
     if (size < 0) {
         spdlog::error("Ingress failed to create ring buffer.");
         return false;
@@ -25,9 +25,7 @@ bool Ingress::create() {
     return true;
 }
 
-void Ingress::destroy() {
-
-}
+void Ingress::destroy() {}
 
 void Ingress::ingestSamples(const float* input, unsigned long frameCount) {
     unsigned long writeAvailable = PaUtil_GetRingBufferWriteAvailable(m_ringBuffer.get());
@@ -36,9 +34,7 @@ void Ingress::ingestSamples(const float* input, unsigned long frameCount) {
     unsigned long framesWritten = PaUtil_WriteRingBuffer(m_ringBuffer.get(), input, elementCount);
 }
 
-unsigned long Ingress::availableFrames() {
-    return PaUtil_GetRingBufferReadAvailable(m_ringBuffer.get()) / m_channels;
-}
+unsigned long Ingress::availableFrames() { return PaUtil_GetRingBufferReadAvailable(m_ringBuffer.get()) / m_channels; }
 
 void Ingress::dropSamples(unsigned long frameCount) {
     PaUtil_AdvanceRingBufferReadIndex(m_ringBuffer.get(), frameCount * m_channels);

--- a/src/audio/Ingress.cpp
+++ b/src/audio/Ingress.cpp
@@ -1,0 +1,40 @@
+#include "audio/Ingress.hpp"
+
+#include "../src/common/pa_ringbuffer.h"
+#include "spdlog/spdlog.h"
+
+namespace scin { namespace audio {
+
+const int kSamplesPerChannel = 8192;
+
+Ingress::Ingress(int channels): m_channels(channels), m_ringBuffer(new PaUtilRingBuffer),
+    m_buffer(new float[kSamplesPerChannel * channels]) {
+}
+
+Ingress::~Ingress() {
+
+}
+
+bool Ingress::create() {
+    ring_buffer_size_t size = PaUtil_InitializeRingBuffer(m_ringBuffer.get(), 4, kSamplesPerChannel * m_channels,
+        m_buffer.get());
+    if (size < 0) {
+        spdlog::error("Ingress failed to create ring buffer.");
+        return false;
+    }
+    return true;
+}
+
+void Ingress::destroy() {
+
+}
+
+void Ingress::ingestSamples(const float* input, unsigned long frameCount) {
+    unsigned long writeAvailable = PaUtil_GetRingBufferWriteAvailable(m_ringBuffer.get());
+    // TODO: logging on buffer oflow, maybe atomically increment a counter?
+    unsigned long elementCount = std::min(frameCount * m_channels, writeAvailable);
+    unsigned long framesWritten = PaUtil_WriteRingBuffer(m_ringBuffer.get(), input, elementCount);
+}
+
+} // namespace audio
+} // namespace scin

--- a/src/audio/Ingress.hpp
+++ b/src/audio/Ingress.hpp
@@ -1,0 +1,34 @@
+#ifndef SRC_AUDIO_INGRESS_HPP_
+#define SRC_AUDIO_INGRESS_HPP_
+
+#include <memory>
+
+struct PaUtilRingBuffer;
+
+namespace scin { namespace audio {
+
+// Represents an input of audio in to the Scintillator system. Uses a lockfree input ringbuffer that can be added to
+// asynchronously anytime. Monitors that queue and can inform a variety of audio consumers within the Scintillator
+// system when there's new data available and what that data might be.
+class Ingress {
+public:
+    Ingress(int channels);
+    ~Ingress();
+
+    bool create();
+    void destroy();
+
+    // Called on realtime audio loop. Needs to always be called by same thread.
+    void ingestSamples(const float* input, unsigned long frameCount);
+
+private:
+    int m_channels;
+
+    std::unique_ptr<PaUtilRingBuffer> m_ringBuffer;
+    std::unique_ptr<float[]> m_buffer;
+};
+
+} // namespace scin
+} // namespace audio
+
+#endif // SRC_AUDIO_INGRESS_HPP_

--- a/src/audio/Ingress.hpp
+++ b/src/audio/Ingress.hpp
@@ -12,7 +12,7 @@ namespace scin { namespace audio {
 // system when there's new data available and what that data might be.
 class Ingress {
 public:
-    Ingress(int channels);
+    Ingress(int channels, int sampleRate);
     ~Ingress();
 
     bool create();
@@ -21,8 +21,21 @@ public:
     // Called on realtime audio loop. Needs to always be called by same thread.
     void ingestSamples(const float* input, unsigned long frameCount);
 
+    // something to get samples available for reading count
+    unsigned long availableFrames();
+
+    // advance read pointer without copying (just drop)
+    void dropSamples(unsigned long frameCount);
+
+    // extract samples
+    unsigned long extractSamples(float* output, unsigned long frameCount);
+
+    int channels() const { return m_channels; }
+    int sampleRate() const { return m_sampleRate; }
+
 private:
     int m_channels;
+    int m_sampleRate;
 
     std::unique_ptr<PaUtilRingBuffer> m_ringBuffer;
     std::unique_ptr<float[]> m_buffer;

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -7,12 +7,12 @@
 #include "spdlog/spdlog.h"
 
 #ifdef __linux__
-#include "pa_jack.h"
+#    include "pa_jack.h"
 #endif
 
 namespace {
 int portAudioCallback(const void* input, void* output, unsigned long frameCount,
-        const PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags, void* userData) {
+                      const PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags, void* userData) {
     scin::audio::PortAudio* audio = static_cast<scin::audio::PortAudio*>(userData);
     if (input && audio->inputChannels()) {
         audio->ingress()->ingestSamples(static_cast<const float*>(input), frameCount);
@@ -24,8 +24,10 @@ int portAudioCallback(const void* input, void* output, unsigned long frameCount,
 
 namespace scin { namespace audio {
 
-PortAudio::PortAudio(int inputChannels, int outputChannels): m_inputChannels(inputChannels),
-    m_outputChannels(outputChannels), m_init(false) {}
+PortAudio::PortAudio(int inputChannels, int outputChannels):
+    m_inputChannels(inputChannels),
+    m_outputChannels(outputChannels),
+    m_init(false) {}
 
 PortAudio::~PortAudio() { destroy(); }
 
@@ -105,8 +107,8 @@ bool PortAudio::create() {
             return false;
         }
         spdlog::info("JACK audio input max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
-            deviceInfo->maxInputChannels, deviceInfo->defaultLowInputLatency, deviceInfo->defaultHighInputLatency,
-            deviceInfo->defaultSampleRate);
+                     deviceInfo->maxInputChannels, deviceInfo->defaultLowInputLatency,
+                     deviceInfo->defaultHighInputLatency, deviceInfo->defaultSampleRate);
         inputStream.suggestedLatency = deviceInfo->defaultLowInputLatency;
         inputStream.device = deviceIndex;
         if (m_inputChannels > deviceInfo->maxInputChannels) {
@@ -140,12 +142,13 @@ bool PortAudio::create() {
             return false;
         }
         spdlog::info("JACK audio output max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
-            deviceInfo->maxOutputChannels, deviceInfo->defaultLowInputLatency, deviceInfo->defaultHighInputLatency,
-            deviceInfo->defaultSampleRate);
+                     deviceInfo->maxOutputChannels, deviceInfo->defaultLowInputLatency,
+                     deviceInfo->defaultHighInputLatency, deviceInfo->defaultSampleRate);
         inputStream.suggestedLatency = deviceInfo->defaultLowInputLatency;
         inputStream.device = deviceIndex;
         if (m_outputChannels > deviceInfo->maxOutputChannels) {
-            spdlog::error("Requested {} output channels, but JACK output configured to support maximum of {} channels.");
+            spdlog::error(
+                "Requested {} output channels, but JACK output configured to support maximum of {} channels.");
             return false;
         }
         sampleRate = deviceInfo->defaultSampleRate;
@@ -156,7 +159,7 @@ bool PortAudio::create() {
     const PaStreamParameters* inputParams = m_inputChannels > 0 ? &inputStream : nullptr;
     const PaStreamParameters* outputParams = m_outputChannels > 0 ? &outputStream : nullptr;
     result = Pa_OpenStream(&stream, inputParams, outputParams, sampleRate, paFramesPerBufferUnspecified, paNoFlag,
-        portAudioCallback, this);
+                           portAudioCallback, this);
     if (result != paNoError) {
         spdlog::error("PortAudio failed to open stream: {}", Pa_GetErrorText(result));
         return false;

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -1,0 +1,141 @@
+#include "audio/PortAudio.hpp"
+
+#include "portaudio.h"
+#include "spdlog/spdlog.h"
+
+#ifdef __linux__
+#include "pa_jack.h"
+#endif
+
+namespace scin { namespace audio {
+
+PortAudio::PortAudio(int inputChannels, int outputChannels, const std::string& inDeviceName,
+    const std::string& outDeviceName, int sampleRate): m_inputChannels(inputChannels), m_outputChannels(outputChannels),
+    m_inDeviceName(inDeviceName), m_outDeviceName(outDeviceName), m_sampleRate(sampleRate), m_init(false) {}
+
+PortAudio::~PortAudio() { destroy(); }
+
+bool PortAudio::create() {
+    if (m_inputChannels <= 0 && m_outputChannels <= 0) {
+        spdlog::info("No input or output audio channels selected, skipping PortAudio initialization");
+        return true;
+    }
+
+    if (m_sampleRate == 0) {
+        spdlog::info("Sample rate of 0 selected for audio system, skipping PortAudio initialization");
+        return true;
+    }
+
+    if (m_init) {
+        spdlog::warn("Duplicate calls to PortAudio::create()");
+        return false;
+    }
+
+    const PaVersionInfo* versionInfo = Pa_GetVersionInfo();
+    spdlog::info("Initializing PortAudio subsystem: {}", versionInfo->versionText);
+
+    PaError result;
+
+#ifdef __linux__
+    result = PaJack_SetClientName("ScintillatorSynth");
+    spdlog::info("Setting PortAudio JACK client name to ScintillatorSynth");
+    if (result != paNoError) {
+        spdlog::error("Failed to set PortAudio JACK client name: {}", Pa_GetErrorText(result));
+        return false;
+    }
+#endif
+
+    spdlog::info("Initializing PortAudio subsystem.");
+    result = Pa_Initialize();
+    if (result != paNoError) {
+        spdlog::error("Failed to initialize PortAudio subsystem: {}", Pa_GetErrorText(result));
+        return false;
+    }
+    m_init = true;
+
+#ifdef __linux__
+    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paJACK);
+    if (apiIndex < 0) {
+        spdlog::error("PortAudio failed to find JACK, is it running? {}.", Pa_GetErrorText(apiIndex));
+        return false;
+    }
+#endif
+
+    const PaHostApiInfo* apiInfo = Pa_GetHostApiInfo(apiIndex);
+    if (!apiInfo) {
+        spdlog::error("Failed to get PortAudio API info.");
+        return false;
+    }
+
+    PaStreamParameters inputStream;
+    if (m_inputChannels > 0) {
+        inputStream.channelCount = m_inputChannels;
+        inputStream.sampleFormat = paFloat32;
+        inputStream.hostApiSpecificStreamInfo = nullptr;
+
+#ifdef __linux__
+        auto deviceIndex = apiInfo->defaultInputDevice;
+        if (deviceIndex == paNoDevice) {
+            spdlog::error("No default input device configured for JACK, is JACK configured correctly?");
+            return false;
+        }
+        const PaDeviceInfo* deviceInfo = Pa_GetDeviceInfo(deviceIndex);
+        if (!deviceInfo) {
+            spdlog::error("Failed to retrieve info about default JACK input device.");
+            return false;
+        }
+        spdlog::info("JACK audio input max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
+            deviceInfo->maxInputChannels, deviceInfo->defaultLowInputLatency, deviceInfo->defaultHighInputLatency,
+            deviceInfo->defaultSampleRate);
+        inputStream.suggestedLatency = deviceInfo->defaultLowInputLatency;
+        inputStream.device = deviceIndex;
+        if (m_inputChannels > deviceInfo->maxInputChannels) {
+            spdlog::error("Requested {} input channels, but JACK input configured to support maximum of {} channels.");
+            return false;
+        }
+#endif
+    }
+
+    PaStreamParameters outputStream;
+    if (m_outputChannels > 0) {
+        outputStream.channelCount = m_outputChannels;
+        outputStream.sampleFormat = paFloat32;
+        outputStream.hostApiSpecificStreamInfo = nullptr;
+
+#ifdef __linux__
+        auto deviceIndex = apiInfo->defaultOutputDevice;
+        if (deviceIndex == paNoDevice) {
+            spdlog::error("No default output device configured for JACK, is JACK configured correctly?");
+            return false;
+        }
+        const PaDeviceInfo* deviceInfo = Pa_GetDeviceInfo(deviceIndex);
+        if (!deviceInfo) {
+            spdlog::error("Failed to retrieve info about default JACK output device.");
+            return false;
+        }
+        spdlog::info("JACK audio output max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
+            deviceInfo->maxOutputChannels, deviceInfo->defaultLowInputLatency, deviceInfo->defaultHighInputLatency,
+            deviceInfo->defaultSampleRate);
+        inputStream.suggestedLatency = deviceInfo->defaultLowInputLatency;
+        inputStream.device = deviceIndex;
+        if (m_outputChannels > deviceInfo->maxOutputChannels) {
+            spdlog::error("Requested {} output channels, but JACK output configured to support maximum of {} channels.");
+            return false;
+        }
+#endif
+    }
+
+
+    return true;
+}
+
+void PortAudio::destroy() {
+    if (m_init) {
+        spdlog::info("Terminating PortAudio subsystem.");
+        Pa_Terminate();
+        m_init = false;
+    }
+}
+
+} // namespace audio
+} // namespace scin

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -113,7 +113,7 @@ bool PortAudio::create() {
             spdlog::error("Requested {} input channels, but JACK input configured to support maximum of {} channels.");
             return false;
         }
-        m_ingress.reset(new Ingress(m_inputChannels));
+        m_ingress.reset(new Ingress(m_inputChannels, deviceInfo->defaultSampleRate));
         if (!m_ingress->create()) {
             spdlog::error("PortAudio failed to create Ingress object.");
             return false;

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -68,6 +68,12 @@ bool PortAudio::create() {
         spdlog::error("PortAudio failed to find JACK, is it running? {}.", Pa_GetErrorText(apiIndex));
         return false;
     }
+#elif (__APPLE__)
+    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paCoreAudio);
+    if (apiIndex < 0) {
+        spdlog::error("PortAudio failed to find CoreAudio: {}.", Pa_GetErrorText(apiIndex));
+        return false;
+    }
 #endif
 
     const PaHostApiInfo* apiInfo = Pa_GetHostApiInfo(apiIndex);

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -74,6 +74,9 @@ bool PortAudio::create() {
         spdlog::error("PortAudio failed to find CoreAudio: {}.", Pa_GetErrorText(apiIndex));
         return false;
     }
+#elif (WIN32)
+    // TODO: settle on preferred Windows audio API. (ASIO?)
+    auto apiIndex = 0;
 #endif
 
     const PaHostApiInfo* apiInfo = Pa_GetHostApiInfo(apiIndex);

--- a/src/audio/PortAudio.hpp
+++ b/src/audio/PortAudio.hpp
@@ -1,9 +1,12 @@
 #ifndef SRC_AUDIO_PORT_AUDIO_H_
 #define SRC_AUDIO_PORT_AUDIO_H_
 
+#include <memory>
 #include <string>
 
 namespace scin { namespace audio {
+
+class Ingress;
 
 // Represents the common interface for sending audio to and receiving audio from the PortAudio abstraction layer.
 class PortAudio {
@@ -15,12 +18,20 @@ public:
     bool create();
 
     void destroy();
+
+    std::shared_ptr<Ingress> ingress() { return m_ingress; }
+
+    int inputChannels() const { return m_inputChannels; }
+    int outputChannels() const { return m_outputChannels; }
+
 private:
     int m_inputChannels;
     int m_outputChannels;
 
     // True if we actually did initalize the PortAudio system, and therefore need to de-init it on destroy().
     bool m_init;
+
+    std::shared_ptr<Ingress> m_ingress;
 };
 
 

--- a/src/audio/PortAudio.hpp
+++ b/src/audio/PortAudio.hpp
@@ -1,0 +1,34 @@
+#ifndef SRC_AUDIO_PORT_AUDIO_H_
+#define SRC_AUDIO_PORT_AUDIO_H_
+
+#include <string>
+
+namespace scin { namespace audio {
+
+// Represents the common interface for sending audio to and receiving audio from the PortAudio abstraction layer.
+class PortAudio {
+public:
+    PortAudio(int inputChannels, int outputChannels, const std::string& inDeviceName, const std::string& outDeviceName,
+            int sampleRate);
+    ~PortAudio();
+
+    // Initialize the PortAudio system and enumerate available devices.
+    bool create();
+
+    void destroy();
+private:
+    int m_inputChannels;
+    int m_outputChannels;
+    std::string m_inDeviceName;
+    std::string m_outDeviceName;
+    int m_sampleRate;
+
+    // True if we actually did initalize the PortAudio system, and therefore need to de-init it on destroy().
+    bool m_init;
+};
+
+
+} // namespace audio
+} // namespace scin
+
+#endif // SRC_AUDIO_PORT_AUDIO_H_

--- a/src/audio/PortAudio.hpp
+++ b/src/audio/PortAudio.hpp
@@ -8,8 +8,7 @@ namespace scin { namespace audio {
 // Represents the common interface for sending audio to and receiving audio from the PortAudio abstraction layer.
 class PortAudio {
 public:
-    PortAudio(int inputChannels, int outputChannels, const std::string& inDeviceName, const std::string& outDeviceName,
-            int sampleRate);
+    PortAudio(int inputChannels, int outputChannels);
     ~PortAudio();
 
     // Initialize the PortAudio system and enumerate available devices.
@@ -19,9 +18,6 @@ public:
 private:
     int m_inputChannels;
     int m_outputChannels;
-    std::string m_inDeviceName;
-    std::string m_outDeviceName;
-    int m_sampleRate;
 
     // True if we actually did initalize the PortAudio system, and therefore need to de-init it on destroy().
     bool m_init;

--- a/src/comp/Async.cpp
+++ b/src/comp/Async.cpp
@@ -4,6 +4,7 @@
 #include "base/Archetypes.hpp"
 #include "comp/Compositor.hpp"
 #include "comp/ScinthDef.hpp"
+#include "infra/Logger.hpp"
 #include "vulkan/Buffer.hpp"
 #include "vulkan/Device.hpp"
 #include "vulkan/Image.hpp"
@@ -114,7 +115,7 @@ void Async::readImageIntoNewBuffer(int bufferID, std::string filePath, int width
 }
 
 void Async::workerThreadMain(std::string threadName) {
-    spdlog::debug("Async worker {} starting up.", threadName);
+    infra::Logger::logVulkanThreadID(threadName);
 
     while (!m_quit) {
         std::function<void()> workFunction;
@@ -160,7 +161,7 @@ void Async::workerThreadMain(std::string threadName) {
 }
 
 void Async::syncThreadMain() {
-    spdlog::debug("Async sync watcher thread starting.");
+    infra::Logger::logVulkanThreadID("Async sync watcher");
 
     while (!m_quit) {
         // First we wait for there to be something in the sync callback queue, meaning a sync is requested.

--- a/src/comp/AudioStager.cpp
+++ b/src/comp/AudioStager.cpp
@@ -1,0 +1,57 @@
+#include "comp/AudioStager.hpp"
+
+#include "audio/Ingress.hpp"
+#include "comp/StageManager.hpp"
+#include "vulkan/Buffer.hpp"
+#include "vulkan/Device.hpp"
+#include "vulkan/Image.hpp"
+
+#include "spdlog/spdlog.h"
+
+namespace scin { namespace comp {
+
+AudioStager::AudioStager(std::shared_ptr<audio::Ingress> ingress): m_ingress(ingress) { }
+
+AudioStager::~AudioStager() {}
+
+bool AudioStager::createBuffers(std::shared_ptr<vk::Device> device) {
+    // TODO: fix hard-coded assumptions about 60Hz sample rate and stereo channels.
+    m_bufferFrameSize = m_ingress->sampleRate() / 60;
+    m_buffer.reset(new vk::HostBuffer(device, vk::Buffer::Kind::kStaging, m_bufferFrameSize * 8));
+    if (!m_buffer->create()) {
+        spdlog::error("AudioStager failed to create HostBuffer of {} bytes", m_bufferFrameSize * 8);
+        return false;
+    }
+
+    m_image.reset(new vk::DeviceImage(device, VK_FORMAT_R32G32_SFLOAT));
+    if (!m_image->create(m_bufferFrameSize, 1)) {
+        spdlog::error("AudioStager failed to create DeviceImage of {} pixels wide", m_bufferFrameSize);
+        return false;
+    }
+    if (!m_image->createView()) {
+        spdlog::error("AudioStager failed to create VkImageView");
+        return false;
+    }
+    return true;
+}
+
+void AudioStager::destroy() {
+    m_buffer.reset();
+    m_image.reset();
+}
+
+void AudioStager::stageAudio(std::shared_ptr<StageManager> stageManager) {
+    // Drop samples greater than two buffer sizes.
+    auto framesAvailable = m_ingress->availableFrames();
+    if (framesAvailable > 2 * m_bufferFrameSize) {
+        auto dropSize = framesAvailable - (2 * m_bufferFrameSize);
+        m_ingress->dropSamples(dropSize);
+    }
+    if (framesAvailable > m_bufferFrameSize) {
+        m_ingress->extractSamples(static_cast<float*>(m_buffer->mappedAddress()), m_bufferFrameSize);
+        stageManager->stageImage(m_buffer, m_image, []{});
+    }
+}
+
+} // namespace comp
+} // namespace scin

--- a/src/comp/AudioStager.cpp
+++ b/src/comp/AudioStager.cpp
@@ -10,7 +10,7 @@
 
 namespace scin { namespace comp {
 
-AudioStager::AudioStager(std::shared_ptr<audio::Ingress> ingress): m_ingress(ingress) { }
+AudioStager::AudioStager(std::shared_ptr<audio::Ingress> ingress): m_ingress(ingress) {}
 
 AudioStager::~AudioStager() {}
 
@@ -49,7 +49,7 @@ void AudioStager::stageAudio(std::shared_ptr<StageManager> stageManager) {
     }
     if (framesAvailable > m_bufferFrameSize) {
         m_ingress->extractSamples(static_cast<float*>(m_buffer->mappedAddress()), m_bufferFrameSize);
-        stageManager->stageImage(m_buffer, m_image, []{});
+        stageManager->stageImage(m_buffer, m_image, [] {});
     }
 }
 

--- a/src/comp/AudioStager.hpp
+++ b/src/comp/AudioStager.hpp
@@ -1,0 +1,45 @@
+#ifndef SRC_COMP_AUDIO_STAGER_HPP_
+#define SRC_COMP_AUDIO_STAGER_HPP_
+
+#include <memory>
+
+namespace scin {
+
+namespace audio {
+class Ingress;
+}
+
+namespace vk {
+class Device;
+class DeviceImage;
+class HostBuffer;
+}
+
+namespace comp {
+class StageManager;
+
+/*! Owned by Compositor, manages a host and device buffer and automates copy of data from Ingress to device.
+ */
+class AudioStager {
+public:
+    AudioStager(std::shared_ptr<audio::Ingress> ingress);
+    ~AudioStager();
+
+    bool createBuffers(std::shared_ptr<vk::Device> device);
+    void destroy();
+
+    void stageAudio(std::shared_ptr<StageManager> stageManager);
+
+    std::shared_ptr<vk::DeviceImage> image() { return m_image; }
+
+private:
+    std::shared_ptr<audio::Ingress> m_ingress;
+    int m_bufferFrameSize;
+    std::shared_ptr<vk::HostBuffer> m_buffer;
+    std::shared_ptr<vk::DeviceImage> m_image;
+};
+
+} // namespace comp
+} // namespace scin
+
+#endif // SRC_COMP_AUDIO_STAGER_HPP_

--- a/src/comp/StageManager.hpp
+++ b/src/comp/StageManager.hpp
@@ -68,6 +68,7 @@ private:
     struct Wait {
         Wait(): fenceIndex(0) {}
         ~Wait() = default;
+        Wait& operator=(const Wait&) = default;
         int fenceIndex;
         std::shared_ptr<vk::CommandBuffer> commands;
         std::vector<std::shared_ptr<vk::HostBuffer>> hostBuffers;

--- a/src/comp/Window.cpp
+++ b/src/comp/Window.cpp
@@ -7,6 +7,7 @@
 #include "comp/RenderSync.hpp"
 #include "comp/StageManager.hpp"
 #include "comp/Swapchain.hpp"
+#include "infra/Logger.hpp"
 #include "vulkan/CommandBuffer.hpp"
 #include "vulkan/CommandPool.hpp"
 #include "vulkan/Device.hpp"
@@ -113,7 +114,7 @@ std::shared_ptr<const FrameTimer> Window::frameTimer() {
 }
 
 void Window::runDirectRendering(std::shared_ptr<comp::Compositor> compositor) {
-    spdlog::info("Window starting direct rendering loop.");
+    infra::Logger::logVulkanThreadID("Windows direct rendering loop");
     m_frameTimer->start();
 
     while (!m_stop && !glfwWindowShouldClose(m_window)) {

--- a/src/infra/Logger.cpp
+++ b/src/infra/Logger.cpp
@@ -146,7 +146,8 @@ void Logger::getCounts(size_t& warningsOut, size_t& errorsOut) { m_errorSink->ge
 
 // static
 void Logger::logVulkanThreadID(const std::string& threadName) {
-    int64_t vulkanThreadID = static_cast<int64_t>(pthread_self());
+    // C-style cast required on MacOS to pass compiler.
+    int64_t vulkanThreadID = (int64_t)(pthread_self());
     spdlog::info("Thread name: {}, Vulkan thread ID: 0x{:x}", threadName, vulkanThreadID);
 }
 

--- a/src/infra/Logger.cpp
+++ b/src/infra/Logger.cpp
@@ -2,7 +2,9 @@
 
 #include "av/AVIncludes.hpp"
 
+#if !(WIN32)
 #include <pthread.h>
+#endif
 
 #include <array>
 #include <mutex>
@@ -145,8 +147,12 @@ void Logger::getCounts(size_t& warningsOut, size_t& errorsOut) { m_errorSink->ge
 
 // static
 void Logger::logVulkanThreadID(const std::string& threadName) {
+#if (WIN32)
+    int64_t vulkanThreadID = (int64_t)GetCurrentThreadId();
+#else
     // C-style cast required on MacOS to pass compiler.
-    int64_t vulkanThreadID = (int64_t)(pthread_self());
+    int64_t vulkanThreadID = (int64_t)pthread_self();
+#endif
     spdlog::info("Thread name: {}, Vulkan thread ID: 0x{:x}", threadName, vulkanThreadID);
 }
 

--- a/src/infra/Logger.cpp
+++ b/src/infra/Logger.cpp
@@ -2,6 +2,8 @@
 
 #include "av/AVIncludes.hpp"
 
+#include <pthread.h>
+
 #include <array>
 #include <mutex>
 
@@ -140,6 +142,13 @@ void Logger::setConsoleLogLevel(int level) {
 }
 
 void Logger::getCounts(size_t& warningsOut, size_t& errorsOut) { m_errorSink->getCounts(warningsOut, errorsOut); }
+
+
+// static
+void Logger::logVulkanThreadID(const std::string& threadName) {
+    int64_t vulkanThreadID = static_cast<int64_t>(pthread_self());
+    spdlog::info("Thread name: {}, Vulkan thread ID: 0x{:x}", threadName, vulkanThreadID);
+}
 
 } // namespace infra
 

--- a/src/infra/Logger.cpp
+++ b/src/infra/Logger.cpp
@@ -143,7 +143,6 @@ void Logger::setConsoleLogLevel(int level) {
 
 void Logger::getCounts(size_t& warningsOut, size_t& errorsOut) { m_errorSink->getCounts(warningsOut, errorsOut); }
 
-
 // static
 void Logger::logVulkanThreadID(const std::string& threadName) {
     // C-style cast required on MacOS to pass compiler.

--- a/src/infra/Logger.cpp
+++ b/src/infra/Logger.cpp
@@ -3,7 +3,7 @@
 #include "av/AVIncludes.hpp"
 
 #if !(WIN32)
-#include <pthread.h>
+#    include <pthread.h>
 #endif
 
 #include <array>

--- a/src/infra/Logger.hpp
+++ b/src/infra/Logger.hpp
@@ -6,6 +6,7 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 
 #include <memory>
+#include <string>
 
 namespace spdlog { namespace sinks {
 class ErrorSink;
@@ -24,6 +25,14 @@ public:
     /*! Returns the number of warnings and errors logged in the application to date.
      */
     void getCounts(size_t& warningsOut, size_t& errorsOut);
+
+    /*! Vulkan uses a different logic to log thread IDs in the validation layer messages, so any thread that handles
+     * VUlkan objects can call this static method to log the Vulkan thread ID, allowing for correlation with the spdlog
+     * thread IDs.
+     *
+     * \param threadName The human-readable name to associate with the thread IDs in the logs.
+     */
+    static void logVulkanThreadID(const std::string& threadName);
 
 private:
     std::shared_ptr<spdlog::sinks::ErrorSink> m_errorSink;

--- a/src/scinsynth.cpp
+++ b/src/scinsynth.cpp
@@ -143,8 +143,8 @@ int main(int argc, char* argv[]) {
     }
 
     // ========== PortAudio setup
-    std::shared_ptr<scin::audio::PortAudio> portAudio(new scin::audio::PortAudio(FLAGS_audioInputChannels,
-        FLAGS_audioOutputChannels));
+    std::shared_ptr<scin::audio::PortAudio> portAudio(
+        new scin::audio::PortAudio(FLAGS_audioInputChannels, FLAGS_audioOutputChannels));
     // Realtime audio only supported on realtime framerates
     if (FLAGS_createWindow && FLAGS_frameRate < 0) {
         if (!portAudio->create()) {

--- a/src/scinsynth.cpp
+++ b/src/scinsynth.cpp
@@ -280,6 +280,11 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
 
+    // Connect audio ingress to compositor if available.
+    if (portAudio->ingress()) {
+        compositor->addAudioIngress(portAudio->ingress(), 1);
+    }
+
     // ========== Main loop.
     if (FLAGS_createWindow) {
         window->run(compositor);

--- a/src/scinsynth.cpp
+++ b/src/scinsynth.cpp
@@ -68,11 +68,6 @@ DEFINE_bool(swiftshader, false,
 
 DEFINE_int32(audioInputChannels, 0, "If non-zero, defines the number of input channels to create via portaudio.");
 DEFINE_int32(audioOutputChannels, 0, "If non-zero, defines the number of output channels to create via portaudio.");
-DEFINE_string(audioInDeviceName, "", "A pattern to match against the audio input device name. If empty will choose "
-        "the default device");
-DEFINE_string(audioOutDeviceName, "", "A pattern to match against the audio output device name. If empty will choose "
-        "the default device");
-DEFINE_int32(audioSampleRate, 44100, "Sample rate to use for input and output audio channels.");
 
 #if (__APPLE__)
 void envCheckAndUnset(const char* name) {
@@ -276,7 +271,7 @@ int main(int argc, char* argv[]) {
 
     // ========== PortAudio setup
     std::shared_ptr<scin::audio::PortAudio> portAudio(new scin::audio::PortAudio(FLAGS_audioInputChannels,
-        FLAGS_audioOutputChannels, FLAGS_audioInDeviceName, FLAGS_audioOutDeviceName, FLAGS_audioSampleRate));
+        FLAGS_audioOutputChannels));
     if (!portAudio->create()) {
         spdlog::error("Failed creating PortAudio subsystem.");
         return EXIT_FAILURE;

--- a/src/vulkan/Image.cpp
+++ b/src/vulkan/Image.cpp
@@ -54,8 +54,8 @@ SwapchainImage::SwapchainImage(std::shared_ptr<Device> device, VkImage image, Vk
 
 SwapchainImage::~SwapchainImage() {}
 
-AllocatedImage::AllocatedImage(std::shared_ptr<Device> device):
-    Image(device, VK_NULL_HANDLE, VK_FORMAT_R8G8B8A8_UNORM, {}),
+AllocatedImage::AllocatedImage(std::shared_ptr<Device> device, VkFormat format):
+    Image(device, VK_NULL_HANDLE, format, {}),
     m_allocation(VK_NULL_HANDLE) {}
 
 AllocatedImage::~AllocatedImage() { destroy(); }
@@ -73,7 +73,7 @@ void AllocatedImage::destroy() {
     }
 }
 
-DeviceImage::DeviceImage(std::shared_ptr<Device> device): AllocatedImage(device) {}
+DeviceImage::DeviceImage(std::shared_ptr<Device> device, VkFormat format): AllocatedImage(device, format) {}
 
 DeviceImage::~DeviceImage() {}
 
@@ -115,13 +115,13 @@ bool DeviceImage::createDeviceImage(uint32_t width, uint32_t height, bool isFram
     return true;
 }
 
-FramebufferImage::FramebufferImage(std::shared_ptr<Device> device): DeviceImage(device) {}
+FramebufferImage::FramebufferImage(std::shared_ptr<Device> device): DeviceImage(device, VK_FORMAT_R8G8B8_UNORM) {}
 
 FramebufferImage::~FramebufferImage() {}
 
 bool FramebufferImage::create(uint32_t width, uint32_t height) { return createDeviceImage(width, height, true); }
 
-HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device) {}
+HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device, VK_FORMAT_R8G8B8_UNORM) {}
 
 HostImage::~HostImage() {}
 

--- a/src/vulkan/Image.cpp
+++ b/src/vulkan/Image.cpp
@@ -115,13 +115,13 @@ bool DeviceImage::createDeviceImage(uint32_t width, uint32_t height, bool isFram
     return true;
 }
 
-FramebufferImage::FramebufferImage(std::shared_ptr<Device> device): DeviceImage(device, VK_FORMAT_R8G8B8_UNORM) {}
+FramebufferImage::FramebufferImage(std::shared_ptr<Device> device): DeviceImage(device, VK_FORMAT_R8G8B8A8_UNORM) {}
 
 FramebufferImage::~FramebufferImage() {}
 
 bool FramebufferImage::create(uint32_t width, uint32_t height) { return createDeviceImage(width, height, true); }
 
-HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device, VK_FORMAT_R8G8B8_UNORM) {}
+HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device, VK_FORMAT_R8G8B8A8_UNORM) {}
 
 HostImage::~HostImage() {}
 

--- a/src/vulkan/Image.hpp
+++ b/src/vulkan/Image.hpp
@@ -58,7 +58,7 @@ public:
  */
 class AllocatedImage : public Image {
 public:
-    explicit AllocatedImage(std::shared_ptr<Device> device);
+    explicit AllocatedImage(std::shared_ptr<Device> device, VkFormat format);
     virtual ~AllocatedImage();
     AllocatedImage(const AllocatedImage&) = delete;
     AllocatedImage& operator=(const AllocatedImage&) = delete;
@@ -78,7 +78,7 @@ protected:
  */
 class DeviceImage : public AllocatedImage {
 public:
-    explicit DeviceImage(std::shared_ptr<Device> device);
+    explicit DeviceImage(std::shared_ptr<Device> device, VkFormat format);
     virtual ~DeviceImage();
     DeviceImage(const DeviceImage&) = delete;
     DeviceImage& operator=(const DeviceImage&) = delete;

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -89,3 +89,4 @@ if(UNIX AND NOT APPLE)
 endif()
 add_subdirectory(portaudio)
 
+### portaudio ringbuffer not distributed with library

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -7,9 +7,9 @@ set(SCIN_EXT_INSTALL_DIR "${PROJECT_BINARY_DIR}/install-ext" CACHE PATH "Scintal
 file(MAKE_DIRECTORY "${SCIN_EXT_INSTALL_DIR}")
 
 if(WIN32)
-	set(SCIN_WIN_X64 -DCMAKE_GENERATOR_PLATFORM=x64)
+    set(SCIN_WIN_X64 -DCMAKE_GENERATOR_PLATFORM=x64)
 else()
-	set(SCIN_WIN_X64 "")
+    set(SCIN_WIN_X64 "")
 endif()
 
 #### liblo
@@ -72,9 +72,20 @@ target_include_directories(VulkanMemoryAllocator PRIVATE "${SCIN_EXT_INSTALL_DIR
 #### googletest
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 if (WIN32)
-	set(gtest_force_shared_crt ON CACHE BOOL "Force googletest to link against shared crt" FORCE)
+    set(gtest_force_shared_crt ON CACHE BOOL "Force googletest to link against shared crt" FORCE)
 endif()
 add_subdirectory(googletest)
 
 #### yaml-cpp
 add_subdirectory(yaml-cpp)
+
+### portaudio
+set(PA_BUILD_STATIC OFF CACHE BOOL "don't build PortAudio static libs" FORCE)
+set(PA_BUILD_SHARED ON CACHE BOOL "build shared PortAudio libs" FORCE)
+set(PA_DISABLE_INSTALL ON CACHE BOOL "don't run the PortAudio installer" FORCE)
+if(UNIX AND NOT APPLE)
+    set(PA_USE_JACK ON CACHE BOOL "force use of JACK on linux" FORCE)
+    set(PA_USE_ALSA OFF CACHE BOOL "disable use of ALSA on linux" FORCE)
+endif()
+add_subdirectory(portaudio)
+

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -80,13 +80,14 @@ add_subdirectory(googletest)
 add_subdirectory(yaml-cpp)
 
 ### portaudio
-set(PA_BUILD_STATIC OFF CACHE BOOL "don't build PortAudio static libs" FORCE)
-set(PA_BUILD_SHARED ON CACHE BOOL "build shared PortAudio libs" FORCE)
+set(PA_BUILD_SHARED OFF CACHE BOOL "don't build shared PortAudio libs" FORCE)
+set(PA_BUILD_STATIC ON CACHE BOOL "build PortAudio static libs" FORCE)
 set(PA_DISABLE_INSTALL ON CACHE BOOL "don't run the PortAudio installer" FORCE)
 if(UNIX AND NOT APPLE)
     set(PA_USE_JACK ON CACHE BOOL "force use of JACK on linux" FORCE)
     set(PA_USE_ALSA OFF CACHE BOOL "disable use of ALSA on linux" FORCE)
+elseif(WIN32)
+    set(PA_DLL_LINK_WITH_STATIC_RUNTIME OFF CACHE BOOL "force portaudio to use shared CRT" FORCE)
 endif()
 add_subdirectory(portaudio)
 
-### portaudio ringbuffer not distributed with library


### PR DESCRIPTION
## Purpose and motivation

First effort on #7. Adds portaudio and configures it for stereo input of audio signals. Realtime audio is only supported on realtime rendering mode. Also found and fixed a race condition in the StageManager and added some commenting to try and find other Vulkan threading issues by adding thread IDs in the logs. Also the texture mapped has a hard-coded imageID of 1 right now, will add OSC commands to map streams to imageIDs later.

## Implementation

Adds Portaudio in third_party. It needs to be a git submodule, as opposed to a cmake ExternalProject, because we rely on a not-normally-exported part of Portaudio, the lockless thread-safe circular queue. 

Audio is added by the callback from portaudio into the queue. Then there's a new Compositor function to read one frame's worth of audio (assuming a hard-coded 60Hz frame for now) into a host-accessible buffer, and then call StageManager to issue a copy command to the GPU to transfer the latest buffer update to a device-only texture with optimal layout.

Right now the audio samples come in channel-interleaved format, so get uploaded to the video card as `vec2` if stereo, and could be `vec4` if quadraphonic. Packed triples of signed floats have limited GPU support and so are officially not supported. This is uploaded to the GPU as a texture image of n = (sample rate / frame rate) texel wide and 1 texel high.

If there's a desire to support an arbitrary number of channels it could be possible to instead upload un-interleaved single floats into an image of x texels wide and a height of 1 texel per channel, so stereo uploads would be n by 2, and quad would be n by 4, 7.1 surround could be n by 8, etc. This is saved for subsequent work, perhaps to be revisited when we add support for uploading audio to the GPU from previously recorded audio and video samples.

## Types of changes

* Bug fix
* Enhancement

## Status

- [ ] This PR is ready for review
