### PR TITLE
adds macos support to portaudio

### DIFF
--- a/src/audio/Ingress.cpp
+++ b/src/audio/Ingress.cpp
@@ -28,9 +28,12 @@ bool Ingress::create() {
 void Ingress::destroy() {}
 
 void Ingress::ingestSamples(const float* input, unsigned long frameCount) {
+    unsigned long elementCount = frameCount * m_channels;
     unsigned long writeAvailable = PaUtil_GetRingBufferWriteAvailable(m_ringBuffer.get());
-    // TODO: logging on buffer oflow, maybe atomically increment a counter?
-    unsigned long elementCount = std::min(frameCount * m_channels, writeAvailable);
+    if (elementCount > writeAvailable) {
+        // Clobber oldest elements if needed.
+        dropSamples(elementCount - writeAvailable);
+    }
     unsigned long framesWritten = PaUtil_WriteRingBuffer(m_ringBuffer.get(), input, elementCount);
 }
 

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -27,7 +27,8 @@ namespace scin { namespace audio {
 PortAudio::PortAudio(int inputChannels, int outputChannels):
     m_inputChannels(inputChannels),
     m_outputChannels(outputChannels),
-    m_init(false) {}
+    m_init(false),
+    m_stream(nullptr) {}
 
 PortAudio::~PortAudio() { destroy(); }
 
@@ -64,22 +65,10 @@ bool PortAudio::create() {
     }
     m_init = true;
 
-#ifdef __linux__
-    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paJACK);
+    auto apiIndex = pickApiIndex();
     if (apiIndex < 0) {
-        spdlog::error("PortAudio failed to find JACK, is it running? {}.", Pa_GetErrorText(apiIndex));
         return false;
     }
-#elif (__APPLE__)
-    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paCoreAudio);
-    if (apiIndex < 0) {
-        spdlog::error("PortAudio failed to find CoreAudio: {}.", Pa_GetErrorText(apiIndex));
-        return false;
-    }
-#elif (WIN32)
-    // TODO: settle on preferred Windows audio API. (ASIO?)
-    auto apiIndex = 0;
-#endif
 
     const PaHostApiInfo* apiInfo = Pa_GetHostApiInfo(apiIndex);
     if (!apiInfo) {
@@ -89,30 +78,30 @@ bool PortAudio::create() {
 
     double sampleRate = 0.0;
 
-    PaStreamParameters inputStream;
+    PaStreamParameters inputStreamParams;
     if (m_inputChannels > 0) {
-        inputStream.channelCount = m_inputChannels;
-        inputStream.sampleFormat = paFloat32;
-        inputStream.hostApiSpecificStreamInfo = nullptr;
+        inputStreamParams.channelCount = m_inputChannels;
+        inputStreamParams.sampleFormat = paFloat32;
+        inputStreamParams.hostApiSpecificStreamInfo = nullptr;
 
-#ifdef __linux__
         auto deviceIndex = apiInfo->defaultInputDevice;
         if (deviceIndex == paNoDevice) {
-            spdlog::error("No default input device configured for JACK, is JACK configured correctly?");
+            spdlog::error("No default audio input device configured.");
             return false;
         }
         const PaDeviceInfo* deviceInfo = Pa_GetDeviceInfo(deviceIndex);
         if (!deviceInfo) {
-            spdlog::error("Failed to retrieve info about default JACK input device.");
+            spdlog::error("Failed to retrieve info about default audio input device.");
             return false;
         }
-        spdlog::info("JACK audio input max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
-                     deviceInfo->maxInputChannels, deviceInfo->defaultLowInputLatency,
+        spdlog::info("Audio input {} max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
+                     deviceInfo->name, deviceInfo->maxInputChannels, deviceInfo->defaultLowInputLatency,
                      deviceInfo->defaultHighInputLatency, deviceInfo->defaultSampleRate);
-        inputStream.suggestedLatency = deviceInfo->defaultLowInputLatency;
-        inputStream.device = deviceIndex;
+        inputStreamParams.suggestedLatency = deviceInfo->defaultLowInputLatency;
+        inputStreamParams.device = deviceIndex;
         if (m_inputChannels > deviceInfo->maxInputChannels) {
-            spdlog::error("Requested {} input channels, but JACK input configured to support maximum of {} channels.");
+            spdlog::error("Requested {} input channels, but audio input configured to support maximum of {} channels.",
+                          m_inputChannels, deviceInfo->maxInputChannels);
             return false;
         }
         m_ingress.reset(new Ingress(m_inputChannels, deviceInfo->defaultSampleRate));
@@ -120,52 +109,55 @@ bool PortAudio::create() {
             spdlog::error("PortAudio failed to create Ingress object.");
             return false;
         }
+
         sampleRate = deviceInfo->defaultSampleRate;
-#endif
     }
 
-    PaStreamParameters outputStream;
+    PaStreamParameters outputStreamParams;
     if (m_outputChannels > 0) {
-        outputStream.channelCount = m_outputChannels;
-        outputStream.sampleFormat = paFloat32;
-        outputStream.hostApiSpecificStreamInfo = nullptr;
+        // TODO: currently dead code, as audio output not yet supported.
+        outputStreamParams.channelCount = m_outputChannels;
+        outputStreamParams.sampleFormat = paFloat32;
+        outputStreamParams.hostApiSpecificStreamInfo = nullptr;
 
-#ifdef __linux__
         auto deviceIndex = apiInfo->defaultOutputDevice;
         if (deviceIndex == paNoDevice) {
-            spdlog::error("No default output device configured for JACK, is JACK configured correctly?");
+            spdlog::error("No default audio output device configured.");
             return false;
         }
         const PaDeviceInfo* deviceInfo = Pa_GetDeviceInfo(deviceIndex);
         if (!deviceInfo) {
-            spdlog::error("Failed to retrieve info about default JACK output device.");
+            spdlog::error("Failed to retrieve info about default audio output device.");
             return false;
         }
-        spdlog::info("JACK audio output max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
+        spdlog::info("Audio output max channels: {}, low latency: {}s, high latency: {}s, default sample rate: {}",
                      deviceInfo->maxOutputChannels, deviceInfo->defaultLowInputLatency,
                      deviceInfo->defaultHighInputLatency, deviceInfo->defaultSampleRate);
-        inputStream.suggestedLatency = deviceInfo->defaultLowInputLatency;
-        inputStream.device = deviceIndex;
+        outputStreamParams.suggestedLatency = deviceInfo->defaultLowInputLatency;
+        outputStreamParams.device = deviceIndex;
         if (m_outputChannels > deviceInfo->maxOutputChannels) {
             spdlog::error(
-                "Requested {} output channels, but JACK output configured to support maximum of {} channels.");
+                "Requested {} output channels, but audio output configured to support maximum of {} channels.");
+            return false;
+        }
+
+        if (sampleRate > 0.0 && sampleRate != deviceInfo->defaultSampleRate) {
+            spdlog::error("Sample rate mismatch between audio input and output, not supported.");
             return false;
         }
         sampleRate = deviceInfo->defaultSampleRate;
-#endif
     }
 
-    PaStream* stream = nullptr;
-    const PaStreamParameters* inputParams = m_inputChannels > 0 ? &inputStream : nullptr;
-    const PaStreamParameters* outputParams = m_outputChannels > 0 ? &outputStream : nullptr;
-    result = Pa_OpenStream(&stream, inputParams, outputParams, sampleRate, paFramesPerBufferUnspecified, paNoFlag,
+    const PaStreamParameters* inputParams = m_inputChannels > 0 ? &inputStreamParams : nullptr;
+    const PaStreamParameters* outputParams = m_outputChannels > 0 ? &outputStreamParams : nullptr;
+    result = Pa_OpenStream(&m_stream, inputParams, outputParams, sampleRate, paFramesPerBufferUnspecified, paNoFlag,
                            portAudioCallback, this);
     if (result != paNoError) {
         spdlog::error("PortAudio failed to open stream: {}", Pa_GetErrorText(result));
         return false;
     }
 
-    result = Pa_StartStream(stream);
+    result = Pa_StartStream(m_stream);
     if (result != paNoError) {
         spdlog::error("PortAudio failed to start stream: {}", Pa_GetErrorText(result));
         return false;
@@ -181,6 +173,31 @@ void PortAudio::destroy() {
         m_init = false;
     }
 }
+
+#ifdef __linux__
+int PortAudio::pickApiIndex() {
+    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paJACK);
+    if (apiIndex < 0) {
+        spdlog::error("PortAudio failed to find JACK, is it running? {}.", Pa_GetErrorText(apiIndex));
+        return -1;
+    }
+    return apiIndex;
+}
+#elif (__APPLE__)
+int PortAudio::pickApiIndex() {
+    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paCoreAudio);
+    if (apiIndex < 0) {
+        spdlog::error("PortAudio failed to find CoreAudio: {}.", Pa_GetErrorText(apiIndex));
+        return -1;
+    }
+    return apiIndex;
+}
+#elif (WIN32)
+int PortAudio::pickApiIndex() {
+    spdlog::error("PortAudio Windows not yet supported.");
+    return -1;
+}
+#endif
 
 } // namespace audio
 } // namespace scin

--- a/src/audio/PortAudio.hpp
+++ b/src/audio/PortAudio.hpp
@@ -4,6 +4,9 @@
 #include <memory>
 #include <string>
 
+// A PortAudio forward declaration to avoid leading the PA header into the rest of Scintillator.
+typedef void PaStream;
+
 namespace scin { namespace audio {
 
 class Ingress;
@@ -25,11 +28,17 @@ public:
     int outputChannels() const { return m_outputChannels; }
 
 private:
+    // Platform-specific functions for PortAudio library configuration.
+    // returns -1 if no suitable API found.
+    int pickApiIndex();
+
     int m_inputChannels;
     int m_outputChannels;
 
     // True if we actually did initalize the PortAudio system, and therefore need to de-init it on destroy().
     bool m_init;
+
+    PaStream* m_stream;
 
     std::shared_ptr<Ingress> m_ingress;
 };

--- a/src/comp/StageManager.hpp
+++ b/src/comp/StageManager.hpp
@@ -63,6 +63,7 @@ private:
     std::shared_ptr<vk::Device> m_device;
     std::shared_ptr<vk::CommandPool> m_commandPool;
     std::vector<VkFence> m_fences;
+    std::vector<std::shared_ptr<vk::CommandBuffer>> m_commands;
     std::function<void()> m_stagingRequested;
 
     struct Wait {


### PR DESCRIPTION
## Purpose and motivation

#125 added support for realtime audio ingestion on Linux. This PR adds the same support for macOS. Windows is to follow.

## Implementation

Tested and verified the PortAudio setup on a Mac. This uncovered that the StageManager software still had a race in CommandBuffer deletion, so devised a better method to fix the race. Started to organize the PortAudio class a bit better to centralize the os-specific logic into methods.

## Types of changes

* Bug fix
* Enhancement

## Status

- [ ] This PR is ready for review
