### PR TITLE
add realtime audio input support on windows

### DIFF
--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -194,8 +194,11 @@ int PortAudio::pickApiIndex() {
 }
 #elif (WIN32)
 int PortAudio::pickApiIndex() {
-    spdlog::error("PortAudio Windows not yet supported.");
-    return -1;
+    auto apiIndex = Pa_HostApiTypeIdToHostApiIndex(PaHostApiTypeId::paMME);
+    if (apiIndex < 0) {
+        spdlog::error("PortAudio failed to find MME: {}.", Pa_GetErrorText(apiIndex));
+    }
+    return apiIndex;
 }
 #endif
 


### PR DESCRIPTION
## Purpose and motivation

Completing the work started in #125 and continued in #126 by adding support for realtime audio ingestion via MME in Windows.

## Implementation

MME was chosen because it seems to have the broadest support story. I was able to route audio from SuperCollider to Scintillator using the donationware software VoiceMeeter.

## Types of changes

* Enhancement

## Status

- [ ] This PR is ready for review
