### PR TITLE
Finalize names and begin support for VGen rates

### DIFF
--- a/HelpSource/Guides/VGens-Overview.schelp
+++ b/HelpSource/Guides/VGens-Overview.schelp
@@ -8,7 +8,8 @@ section::Video Oscillators
 There are only a few test oscillators implemented for now, with plans to add many more. One key conceptual difference between SuperCollider audio oscillators and Scintillator video oscillators to bear in mind is that video signals are constrained to values between code::[0, 1]::, unlike audio signals, which operate normally between code::[-1, 1]::.
 
 table::
-## link::Classes/VSinOsc::code::.fr(freq, phas, mul, add):: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/VSinOsc::code::.fr(freq, phas, mul, add):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 1
 ## 2, 2, 2, 2 || 2
@@ -16,7 +17,7 @@ table::
 ## 4, 4, 4, 4 || 4
 :: || Piecewise sinusodal oscillator, analogous to link::Classes/SinOsc::
 
-## link::Classes/VSaw::code::.fr(freq, phas, mul, add):: || table::
+## link::Classes/VSaw::code::.fr(freq, phas, mul, add):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 1
 ## 2, 2, 2, 2 || 2
@@ -30,17 +31,18 @@ section::Image Sampling
 VGens for reading from link::Classes/ImageBuffer:: objects.
 
 table::
-## link::Classes/Sampler::code::.fr(image, pos):: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/Sampler::code::.fr(image, pos):: || pixel || table::
 ## strong::input:: || strong::output::
 ## image, 2 || 4
 :: || Samples the provided imageBuffer at code::pos:: and returns the 4D color signal as code::(r, g, b, a)::
 
-## link::Classes/TexPos::code::.fr():: || table::
+## link::Classes/TexPos::code::.fr():: || shape, pixel || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Texture Sampler position
 
-## link::Classes/TextureSize::code::.fr(image):: || table::
+## link::Classes/TextureSize::code::.fr(image):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Returns the dimensions in pixels of the provided ImageBuffer. Roughly analogous to link::Classes/BufFrames::.
@@ -51,17 +53,18 @@ section::Fragment Position
 Scintillator offers a few different means to determine the position of the current fragment shader relative to the geometry being rendered, or the onscreen pixel dimensions. The link::Classes/TexPos:: VGen is in the Image Sampling section.
 
 table::
-## link::Classes/NormPos::code::.fr():: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/NormPos::code::.fr():: || shape, pixel || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Normalized fragment position
 
-## link::Classes/TexPos::code::.fr():: || table::
+## link::Classes/TexPos::code::.fr():: || shape, pixel || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Texture Sampler position
 
-## link::Classes/FragCoord::code::.fr():: || table::
+## link::Classes/FragCoord::code::.fr():: || pixel || table::
 ## strong::input:: || strong::output::
 ## - || 2
 :: || Onscreen coordinates of current fragment in pixels
@@ -76,33 +79,33 @@ subsection::Building Vectors
 Some VGens require inputs that are higher-dimensional vectors. To construct those inputs from single-dimensional components, Scintillator provides the code::VecN:: classes.
 
 table::
-## strong::VGen:: || strong::dimensions:: || strong::description::
-## link::Classes/Vec2::code::.fr(x, y):: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/Vec2::code::.fr(x, y):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 2
 :: || Construct a 2D vector from individual elements code::x:: and code::y::
 
-## link::Classes/Vec3::code::.fr(x, y, z):: || table::
+## link::Classes/Vec3::code::.fr(x, y, z):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 3
 :: || Construct a 3D vector from individual elements code::x:: and code::y::
 
-## link::Classes/Vec4::code::.fr(x, y, z, w):: || table::
+## link::Classes/Vec4::code::.fr(x, y, z, w):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 4
 :: || Construct a 4D vector from individual elements code::x:: and code::y::
 
-## link::Classes/Splat2::code::.fr(x):: || table::
+## link::Classes/Splat2::code::.fr(x):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1 || 2
 :: || Construct a 2D vector from a single element copied into both
 
-## link::Classes/Splat3::code::.fr(x):: || table::
+## link::Classes/Splat3::code::.fr(x):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1 || 3
 :: || Construct a 3D vector from a single element copied into both
 
-## link::Classes/Splat4::code::.fr(x):: || table::
+## link::Classes/Splat4::code::.fr(x):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1 || 4
 :: || Construct a 4D vector from a single element copied into both
@@ -113,8 +116,8 @@ subsection::Accessing Elements Within Vectors
 To break out a single-dimensional signal from a higher-dimensional vector, use the code::VN:: classes. These follow the computer graphics naming conventions for elements within the vector, where the names emphasis::x, y, z, w:: are used to indicate the first through fourth element respectively.
 
 table::
-## strong::VGen:: || strong::dimensions:: || strong::description::
-## link::Classes/VX::code::.fr(v):: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/VX::code::.fr(v):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1 || 1
 ## 2 || 1
@@ -122,20 +125,20 @@ table::
 ## 4 || 1
 :: || Return the first element in the vector.
 
-## link::Classes/VY::code::.fr(v):: || table::
+## link::Classes/VY::code::.fr(v):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 2 || 1
 ## 3 || 1
 ## 4 || 1
 :: || Return the second element in the vector.
 
-## link::Classes/VZ::code::.fr(v):: || table::
+## link::Classes/VZ::code::.fr(v):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 3 || 1
 ## 4 || 1
 :: || Return the third element in the vector.
 
-## link::Classes/VW::code::.fr(v):: || table::
+## link::Classes/VW::code::.fr(v):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 4 || 1
 :: || Return the fourth element in the vector.
@@ -146,17 +149,18 @@ subsection::Video Output Convenience
 Any 4D output is considered valid link::Classes/ScinthDef:: output.
 
 table::
-## link::Classes/RGBOut::code::.fr(r, g, b):: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/RGBOut::code::.fr(r, g, b):: || pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 4
 :: || Convenience object for color output at full alpha
 
-## link::Classes/RGBAOut::code::.fr(r, g, b):: || table::
+## link::Classes/RGBAOut::code::.fr(r, g, b):: || pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1, 1 || 4
 :: || Convenience object for color output with alpha channel
 
-## link::Classes/BWOut::code::.fr(x):: || table::
+## link::Classes/BWOut::code::.fr(x):: || pixel || table::
 ## strong::input:: || strong::output::
 ## 1 || 4
 :: || Convenience object for black and white output at full alpha
@@ -169,8 +173,8 @@ Scintillator offers per-element (or emphasis::piecewise::) operations as well as
 subsection::Vector Operations
 
 table::
-## strong::VGen:: || strong::dimensions:: || strong::description::
-## link::Classes/Clamp::code::.fr(x, min, max):: || table::
+## strong::VGen:: || strong::Rates:: || strong::Dimensions:: || strong::Description::
+## link::Classes/Clamp::code::.fr(x, min, max):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 1
 ## 2, 2, 2 || 2
@@ -178,7 +182,7 @@ table::
 ## 4, 4, 4 || 4
 :: || Video equivalent of link::Classes/Clip:: UGen, piecewise bounds input code::x:: between code::[min, max]::
 
-## link::Classes/Length::code::.fr(x):: || table::
+## link::Classes/Length::code::.fr(x):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1 || 1
 ## 2 || 1
@@ -186,14 +190,14 @@ table::
 ## 4 || 1
 :: || Returns the length of the vector code::x::, or the square root of the sum of the squares
 
-## link::Classes/Distance::code::.fr(x, y):: || table::
+## link::Classes/Distance::code::.fr(x, y):: || frame, shape, pixel || table::
 ## 1, 1 || 1
 ## 2, 2 || 1
 ## 3, 3 || 1
 ## 4, 4 || 1
 :: || Computes the distance between code::x:: and code::y::, which is the length of the vector code::x - y::
 
-## link::Classes/Step::code::.fr(step, x):: || table::
+## link::Classes/Step::code::.fr(step, x):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 1
 ## 2, 2 || 2
@@ -201,7 +205,7 @@ table::
 ## 4, 4 || 4
 :: || Just like the binary operator code::thresh::, returns code::0:: when code::x < step::, otherwise code::x::
 
-## link::Classes/VecMix::code::.fr(x, y, a):: || table::
+## link::Classes/VecMix::code::.fr(x, y, a):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1, 1 || 1
 ## 2, 2, 1 || 2
@@ -212,7 +216,7 @@ table::
 ## 4, 4, 4 || 4
 :: || Similar to the binary operator code::blend::, returns a linear mix of code::x, y:: with code::a:: between code::[0, 1]::. Supports piecewise comparison or a single blend argument to apply to all components
 
-## link::Classes/Dot::code::.fr(x, y):: || table::
+## link::Classes/Dot::code::.fr(x, y):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 1
 ## 2, 2 || 1
@@ -220,12 +224,12 @@ table::
 ## 4, 4 || 1
 :: || Returns the dot product between code::x:: and code::y::, or the sum of the product of each component in the vector
 
-## link::Classes/Cross::code::.fr(x, y):: || table::
+## link::Classes/Cross::code::.fr(x, y):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 3, 3 || 3
 :: || Returns the cross product of code::x:: and code::y::
 
-## link::Classes/VNorm::code::.fr(x):: || table::
+## link::Classes/VNorm::code::.fr(x):: || frame, shape, pixel || table::
 ## strong::input:: || strong::output::
 ## 1, 1 || 1
 ## 2, 2 || 2
@@ -243,7 +247,7 @@ For documentation of these operators in base SuperCollider see the link::Overvie
 
 The following tables detail the current supported operations along with the ones that are not yet supported, the name of the VGen sent to the server to realize the operation, a brief explanation of their function and conceptual mathematical code. Since all numbers within a Scintillator link::Classes/ScinthDef:: must be floating-point, several of the integer operations like bit manipulation are marked as emphasis::not applicable::. If support is planned, but not yet implemented, the function is marked as emphasis::not yet implemented::.
 
-All unary operations support inputs in 1-4 dimensions, and produce outputs of the same dimension. For higher-dimensional signals all operations happen emphasis::piecewise::, meaning the operator is applied to each component of the signal independently. For example if code::b = a.neg:: and both code::a:: and code::b:: are link::Classes/Vec4:: objects then:
+For higher-dimensional signals all operations happen emphasis::piecewise::, meaning the operator is applied to each component of the signal independently. For example if code::b = a.neg:: and both code::a:: and code::b:: are link::Classes/Vec4:: objects then:
 
 code::
 b = Vec4.fr(
@@ -251,6 +255,10 @@ b = Vec4.fr(
 	VY.fr(a).neg,
 	VZ.fr(a).neg,
 	VW.fr(a).neg);
+::
+
+note::
+All unary operations are supported at all rates, support inputs in 1-4 dimensions, and produce outputs of the same dimension.
 ::
 
 table::

--- a/HelpSource/Reference/Scintillator-ScinthDef-File-Format.schelp
+++ b/HelpSource/Reference/Scintillator-ScinthDef-File-Format.schelp
@@ -38,7 +38,7 @@ Individual VGens are specified as YAML dictionaries and have the following keys:
 table::
 ## strong::key:: || strong::YAML type:: || strong::notes::
 ## code::className:: || string || name of the VGen class, must match the name of a VGen configured on the server
-## code::rate:: || string || currently either code::fragment:: or code::vertex::
+## code::rate:: || string || one of code::frame::, code::shape::, or code::pixel::
 ## code::sampler:: || dictionary || Only required for sampling VGens. Specifies sampler parameters.
 ## code::inputs:: || list || input YAML dictionaries in an ordered list. May be absent if VGen has no inputs.
 ## code::outputs:: || list || output YAML dictionaries in an ordered list

--- a/HelpSource/Reference/VGen-File-Format.schelp
+++ b/HelpSource/Reference/VGen-File-Format.schelp
@@ -3,13 +3,14 @@ summary:: Description of VGen yaml file format used by Scintillator synth server
 categories:: Quarks>Scintillator>Developer Documentation
 related:: Classes/VGen, Classes/ScinthDef, Reference/Scintillator-ScinthDef-File-Format
 
-section::File Format
+section::Top-Level Format
 
 A VGen file may contain multiple VGen definitions. Each definition at top level is a yaml dictionary with required and optional keys.
 
 table::
 ## strong::key name:: || strong::type:: || strong::required or optional:: || strong::description::
 ## code::name:: || string || strong::required:: || The name of the VGen, must be unique. Used to identify this VGen in ScinthDef descriptions.
+## code::rates:: || list || strong::required:: || A list of strings identifying the rates the VGen supports, at least one of code::frame::, code::shape::, code::pixel::.
 ## code::sampler:: || boolean || optional || If present, specifies if this VGen is a sampling VGen that will take an image input. If not present, the value is assumed to be false.
 ## code::inputs:: || list || optional || A list identifying input names in the shader program. The ordering of inputs here must match the ordering of inputs on the ScinthDef, as those inputs can be supplied unnamed.
 ## code::outputs:: || list || strong::required:: || A list of strings identifying names of output parameters. At least one element must exist in this list.
@@ -17,7 +18,7 @@ table::
 ## code::shader:: || string || strong::required:: || The GLSL shader program, with inputs, intrinsics, and intermediates, as well as exactly one instance of the keyword "@out" prefixed with @ symbols.
 ::
 
-subsection::dimensions list
+subsection::Input and Output Dimensions List
 
 The dimensions list enumerates the valid dimensions of input to, and output from, the VGen. As shader programs rely heavily on SIMD this means that many different configurations of output and input dimensions are typically supported by the built-in functions. The code::dimension:: key must be present in a valid VGen and contain a list with one or more dictionary elements with the following keys:
 
@@ -29,11 +30,7 @@ table::
 
 note::If a list, must have the same number of integer elements as there are number of inputs or outputs, each integer describing the dimensionality of inputs or outputs in order. If a single integer, all inputs or outputs are assumed to have that dimensionality.::
 
-section::Input and Output Dimensions
-
-Current VGen design assumes zero or more inputs, and exactly one output from each VGen. VGen inputs and outputs each have a emphasis::dimension:: value from 1 to 4.
-
-section::Intrinsics
+subsection::Shader Intrinsics
 
 Some @names are reserved and will be automatically supplied to the VGen at compilation or runtime. They are described in short table form, with detailed descriptions below.
 

--- a/classes/BasicOpsVGen.sc
+++ b/classes/BasicOpsVGen.sc
@@ -94,7 +94,7 @@ UnaryOpVGen : BasicOpVGen {
 
 BinaryOpVGen : BasicOpVGen {
 	*new { |selector, a, b|
-		var binaryName;
+		var binaryName, rate;
 		switch (selector,
 			'rotate', { ^thisMethod.notYetImplemented },
 			'dist', { ^thisMethod.notYetImplemented },
@@ -152,12 +152,23 @@ BinaryOpVGen : BasicOpVGen {
 			'nand', { ^thisMethod.notYetImplemented },
 			{ "Unknown VGen binary operation: %".format(selector).error; ^nil; }
 		);
-		^this.multiNew(\fragment, binaryName, a, b);
+		// Rate is implied from argument operators. If they have the same rate
+		if (a.rate === b.rate, {
+			rate = a.rate;
+		}, {
+			// Pick fastest rate between the relevant VGens.
+			if (a.rate === \pixel or: { b.rate === \pixel }, {
+				rate = \pixel;
+			}, {
+				// Rates are unequal and not pixel so the fastest rate must be shape.
+				rate = \shape;
+			});
+		});
+		^this.multiNew(rate, binaryName, a, b);
 	}
 
 	init { |binaryName, a, b|
 		vgenName = binaryName;
-		rate = \fragment;
 		inputs = [a, b];
 	}
 

--- a/classes/BuiltIn.sc
+++ b/classes/BuiltIn.sc
@@ -1,6 +1,14 @@
 Clamp : VGen {
 	*fr { |x, min, max|
-		^this.multiNew(\fragment, x, min, max);
+		^this.multiNew(\frame, x, min, max);
+	}
+
+	*sr { |x, min, max|
+		^this.multiNew(\shape, x, min, max);
+	}
+
+	*pr { |x, min, max|
+		^this.multiNew(\pixel, x, min, max);
 	}
 
 	inputDimensions {
@@ -15,7 +23,15 @@ Clamp : VGen {
 
 Cross : VGen {
 	*fr { |x, y|
-		^this.multiNew(\fragment, x, y);
+		^this.multiNew(\frame, x, y);
+	}
+
+	*sr { |x, y|
+		^this.multiNew(\shape, x, y);
+	}
+
+	*pr { |x, y|
+		^this.multiNew(\pixel, x, y);
 	}
 
 	inputDimensions {
@@ -29,7 +45,15 @@ Cross : VGen {
 
 Dot : VGen {
 	*fr { |x, y|
-		^this.multiNew(\fragment, x, y);
+		^this.multiNew(\frame, x, y);
+	}
+
+	*sr { |x, y|
+		^this.multiNew(\shape, x, y);
+	}
+
+	*pr { |x, y|
+		^this.multiNew(\pixel, x, y);
 	}
 
 	inputDimensions {
@@ -43,7 +67,15 @@ Dot : VGen {
 
 Distance : VGen {
 	*fr { |x, y|
-		^this.multiNew(\fragment, x, y);
+		^this.multiNew(\frame, x, y);
+	}
+
+	*sr { |x, y|
+		^this.multiNew(\shape, x, y);
+	}
+
+	*pr { |x, y|
+		^this.multiNew(\pixel, x, y);
 	}
 
 	inputDimensions {
@@ -57,7 +89,15 @@ Distance : VGen {
 
 FragCoord : VGen {
 	*fr {
-		^this.multiNew(\fragment);
+		^this.multiNew(\frame);
+	}
+
+	*sr {
+		^this.multiNew(\shape);
+	}
+
+	*pr {
+		^this.multiNew(\pixel);
 	}
 
 	inputDimensions {
@@ -71,7 +111,15 @@ FragCoord : VGen {
 
 Length : VGen {
 	*fr { |vec|
-		^this.multiNew(\fragment, vec);
+		^this.multiNew(\frame, vec);
+	}
+
+	*sr { |vec|
+		^this.multiNew(\shape, vec);
+	}
+
+	*pr { |vec|
+		^this.multiNew(\pixel, vec);
 	}
 
 	inputDimensions {
@@ -85,7 +133,15 @@ Length : VGen {
 
 Step : VGen {
 	*fr { |step, x|
-		^this.multiNew(\fragment, step, x);
+		^this.multiNew(\frame, step, x);
+	}
+
+	*sr { |step, x|
+		^this.multiNew(\shape, step, x);
+	}
+
+	*pr { |step, x|
+		^this.multiNew(\pixel, step, x);
 	}
 
 	inputDimensions {
@@ -99,7 +155,15 @@ Step : VGen {
 
 VecMix : VGen {
 	*fr { |x, y, a|
-		^this.multiNew(\fragment, x, y, a);
+		^this.multiNew(\frame, x, y, a);
+	}
+
+	*sr { |x, y, a|
+		^this.multiNew(\shape, x, y, a);
+	}
+
+	*pr { |x, y, a|
+		^this.multiNew(\pixel, x, y, a);
 	}
 
 	inputDimensions {
@@ -113,7 +177,15 @@ VecMix : VGen {
 
 VNorm : VGen {
 	*fr { |x|
-		^this.multiNew(\fragment, x);
+		^this.multiNew(\frame, x);
+	}
+
+	*sr { |x|
+		^this.multiNew(\shape, x);
+	}
+
+	*pr { |x|
+		^this.multiNew(\pixel, x);
 	}
 
 	inputDimensions {

--- a/classes/InOut.sc
+++ b/classes/InOut.sc
@@ -43,7 +43,7 @@ RGBAOut : VGen {
 VControl : MultiOutVGen {
 	var <>values;
 
-	new { |values|
+	*new { |values|
 		// Rate is ignored in the ScinthDef construction.
 		^this.multiNewList([\param] ++ values.asArray);
 	}

--- a/classes/InOut.sc
+++ b/classes/InOut.sc
@@ -1,6 +1,6 @@
 RGBOut : VGen {
-	*fr { |r, g, b|
-		^this.multiNew(\fragment, r, g, b);
+	*pr { |r, g, b|
+		^this.multiNew(\pixel, r, g, b);
 	}
 
 	inputDimensions {
@@ -13,8 +13,8 @@ RGBOut : VGen {
 }
 
 BWOut : VGen {
-	*fr { |v|
-		^this.multiNew(\fragment, v);
+	*pr { |v|
+		^this.multiNew(\pixel, v);
 	}
 
 	inputDimensions {
@@ -27,8 +27,8 @@ BWOut : VGen {
 }
 
 RGBAOut : VGen {
-	*fr { |r, g, b, a|
-		^this.multiNew(\fragment, r, g, b, a);
+	*pr { |r, g, b, a|
+		^this.multiNew(\pixel, r, g, b, a);
 	}
 
 	inputDimensions {
@@ -43,9 +43,9 @@ RGBAOut : VGen {
 VControl : MultiOutVGen {
 	var <>values;
 
-	// TODO: it is not accurate to call these fragment rate.
-	*fr { |values|
-		^this.multiNewList([\fragment] ++ values.asArray);
+	new { |values|
+		// Rate is ignored in the ScinthDef construction.
+		^this.multiNewList([\param] ++ values.asArray);
 	}
 
 	init { |...argValues|

--- a/classes/Intrinsics.sc
+++ b/classes/Intrinsics.sc
@@ -1,6 +1,10 @@
 NormPos : VGen {
-	*fr {
-		^this.multiNew(\fragment);
+	*sr {
+		^this.multiNew(\shape);
+	}
+
+	*pr {
+		^this.multiNew(\pixel);
 	}
 
 	inputDimensions {
@@ -13,8 +17,12 @@ NormPos : VGen {
 }
 
 TexPos : VGen {
-	*fr {
-		^this.multiNew(\fragment);
+	*sr {
+		^this.multiNew(\shape);
+	}
+
+	*pr {
+		^this.multiNew(\pixel);
 	}
 
 	inputDimensions {

--- a/classes/Sampler.sc
+++ b/classes/Sampler.sc
@@ -17,8 +17,8 @@ Sampler : VGen {
 	// one of \transparentBlack, \black, \white, only used if addressMode is set to \clampToBorder.
 	var <>clampBorderColor = \transparentBlack;
 
-	*fr { |image, pos|
-		^this.multiNew(\fragment, pos).prSetupImageInput(image);
+	*pr { |image, pos|
+		^this.multiNew(\pixel, pos).prSetupImageInput(image);
 	}
 
 	// Sets both U and V address modes at the same time.
@@ -56,7 +56,15 @@ Sampler : VGen {
 
 TextureSize : Sampler {
 	*fr { |image|
-		^this.multiNew(\fragment).prSetupImageInput(image);
+		^this.multiNew(\frame).prSetupImageInput(image);
+	}
+
+	*sr { |image|
+		^this.multiNew(\shape).prSetupImageInput(image);
+	}
+
+	*pr { |image|
+		^this.multiNew(\pixel).prSetupImageInput(image);
 	}
 
 	inputDimensions {

--- a/classes/VGen.sc
+++ b/classes/VGen.sc
@@ -9,8 +9,8 @@ VGen : AbstractFunction {
 
 	*singleNew { | rate ... args |
 		if (rate.isKindOf(Symbol).not or:
-			{ rate != \pixel and: { rate != \shape } and: { rate != \frame } }, {
-				Error("rate must be one of 'frame', 'shape', or 'vertex'").throw;
+			{ rate != \pixel and: { rate != \shape } and: { rate != \frame } and: { rate != \param } }, {
+				Error("Unknown VGen rate %, must be one of 'frame', 'shape', or 'pixel'".format(rate)).throw;
 		});
 		^super.new.rate_(rate).addToScinth.init(*args);
 	}

--- a/classes/VGen.sc
+++ b/classes/VGen.sc
@@ -2,15 +2,15 @@ VGen : AbstractFunction {
 	classvar <>buildScinthDef;
 	var <>scinthDef;
 	var <>inputs;
-	var <>rate = \fragment;
+	var <>rate = \pixel;
 	var <>scinthIndex;
 	var <>inDims;
 	var <>outDims;
 
 	*singleNew { | rate ... args |
 		if (rate.isKindOf(Symbol).not or:
-			{ rate != \fragment and: { rate != \vertex } }, {
-				Error("rate must be one of 'fragment' or 'vertex'").throw;
+			{ rate != \pixel and: { rate != \shape } and: { rate != \frame } }, {
+				Error("rate must be one of 'frame', 'shape', or 'vertex'").throw;
 		});
 		^super.new.rate_(rate).addToScinth.init(*args);
 	}
@@ -134,7 +134,9 @@ VGen : AbstractFunction {
 
 	methodSelectorForRate {
 		^switch(rate)
-		{\fragment} { \fr }
+		{ \frame } { \fr }
+		{ \shape } { \sr }
+		{ \pixel } { \pr }
 		{nil}
 	}
 }

--- a/classes/VOsc.sc
+++ b/classes/VOsc.sc
@@ -1,6 +1,14 @@
 VSinOsc : VGen {
 	*fr { |freq = 1.0, phase = 0.0, mul = 0.5, add = 0.5|
-		^this.multiNew(\fragment, freq, phase, mul, add);
+		^this.multiNew(\frame, freq, phase, mul, add);
+	}
+
+	*sr { |freq = 1.0, phase = 0.0, mul = 0.5, add = 0.5|
+		^this.multiNew(\shape, freq, phase, mul, add);
+	}
+
+	*pr { |freq = 1.0, phase = 0.0, mul = 0.5, add = 0.5|
+		^this.multiNew(\pixel, freq, phase, mul, add);
 	}
 
 	inputDimensions {
@@ -14,7 +22,15 @@ VSinOsc : VGen {
 
 VSaw : VGen {
 	*fr { |freq = 1.0, phase = 0.0|
-		^this.multiNew(\fragment, freq, phase);
+		^this.multiNew(\frame, freq, phase);
+	}
+
+	*sr { |freq = 1.0, phase = 0.0|
+		^this.multiNew(\shape, freq, phase);
+	}
+
+	*pr { |freq = 1.0, phase = 0.0|
+		^this.multiNew(\pixel, freq, phase);
 	}
 
 	inputDimensions {

--- a/classes/Vectors.sc
+++ b/classes/Vectors.sc
@@ -1,6 +1,14 @@
 Vec2 : VGen {
 	*fr { |x = 0.0, y = 0.0|
-		^this.multiNew(\fragment, x, y);
+		^this.multiNew(\frame, x, y);
+	}
+
+	*sr { |x = 0.0, y = 0.0|
+		^this.multiNew(\shape, x, y);
+	}
+
+	*pr { |x = 0.0, y = 0.0|
+		^this.multiNew(\pixel, x, y);
 	}
 
 	inputDimensions {
@@ -14,7 +22,15 @@ Vec2 : VGen {
 
 Vec3 : VGen {
 	*fr { |x = 0.0, y = 0.0, z = 0.0|
-		^this.multiNew(\fragment, x, y, z);
+		^this.multiNew(\frame, x, y, z);
+	}
+
+	*sr { |x = 0.0, y = 0.0, z = 0.0|
+		^this.multiNew(\shape, x, y, z);
+	}
+
+	*pr { |x = 0.0, y = 0.0, z = 0.0|
+		^this.multiNew(\pixel, x, y, z);
 	}
 
 	inputDimensions {
@@ -28,7 +44,15 @@ Vec3 : VGen {
 
 Vec4 : VGen {
 	*fr { |x = 0.0, y = 0.0, z = 0.0, w = 0.0|
-		^this.multiNew(\fragment, x, y, z, w);
+		^this.multiNew(\frame, x, y, z, w);
+	}
+
+	*sr { |x = 0.0, y = 0.0, z = 0.0, w = 0.0|
+		^this.multiNew(\shape, x, y, z, w);
+	}
+
+	*pr { |x = 0.0, y = 0.0, z = 0.0, w = 0.0|
+		^this.multiNew(\pixel, x, y, z, w);
 	}
 
 	inputDimensions {
@@ -42,7 +66,15 @@ Vec4 : VGen {
 
 VX : VGen {
 	*fr { |vec|
-		^this.multiNew(\fragment, vec);
+		^this.multiNew(\frame, vec);
+	}
+
+	*sr { |vec|
+		^this.multiNew(\shape, vec);
+	}
+
+	*pr { |vec|
+		^this.multiNew(\pixel, vec);
 	}
 
 	inputDimensions {
@@ -56,7 +88,15 @@ VX : VGen {
 
 VY : VGen {
 	*fr { |vec|
-		^this.multiNew(\fragment, vec);
+		^this.multiNew(\frame, vec);
+	}
+
+	*sr { |vec|
+		^this.multiNew(\shape, vec);
+	}
+
+	*pr { |vec|
+		^this.multiNew(\pizel, vec);
 	}
 
 	inputDimensions {
@@ -70,7 +110,15 @@ VY : VGen {
 
 VZ : VGen {
 	*fr { |vec|
-		^this.multiNew(\fragment, vec);
+		^this.multiNew(\frame, vec);
+	}
+
+	*sr { |vec|
+		^this.multiNew(\shape, vec);
+	}
+
+	*pr { |vec|
+		^this.multiNew(\pixel, vec);
 	}
 
 	inputDimensions {
@@ -85,7 +133,15 @@ VZ : VGen {
 
 VW : VGen {
 	*fr { |vec|
-		^this.multiNew(\fragment, vec);
+		^this.multiNew(\frame, vec);
+	}
+
+	*sr { |vec|
+		^this.multiNew(\shape, vec);
+	}
+
+	*pr { |vec|
+		^this.multiNew(\pixel, vec);
 	}
 
 	inputDimensions {
@@ -99,7 +155,15 @@ VW : VGen {
 
 Splat2 : VGen {
 	*fr { |x|
-		^this.multiNew(\fragment, x);
+		^this.multiNew(\frame, x);
+	}
+
+	*sr { |x|
+		^this.multiNew(\shape, x);
+	}
+
+	*pr { |x|
+		^this.multiNew(\pixel, x);
 	}
 
 	inputDimensions {
@@ -113,7 +177,15 @@ Splat2 : VGen {
 
 Splat3 : VGen {
 	*fr { |x|
-		^this.multiNew(\fragment, x);
+		^this.multiNew(\frame, x);
+	}
+
+	*sr { |x|
+		^this.multiNew(\shape, x);
+	}
+
+	*pr { |x|
+		^this.multiNew(\pixel, x);
 	}
 
 	inputDimensions {
@@ -127,7 +199,15 @@ Splat3 : VGen {
 
 Splat4 : VGen {
 	*fr { |x|
-		^this.multiNew(\fragment, x);
+		^this.multiNew(\frame, x);
+	}
+
+	*sr { |x|
+		^this.multiNew(\shape, x);
+	}
+
+	*pr { |x|
+		^this.multiNew(\pixel, x);
 	}
 
 	inputDimensions {
@@ -138,5 +218,3 @@ Splat4 : VGen {
 		^[[4]];
 	}
 }
-
-

--- a/classes/Vectors.sc
+++ b/classes/Vectors.sc
@@ -96,7 +96,7 @@ VY : VGen {
 	}
 
 	*pr { |vec|
-		^this.multiNew(\pizel, vec);
+		^this.multiNew(\pixel, vec);
 	}
 
 	inputDimensions {

--- a/src/base/AbstractVGen.cpp
+++ b/src/base/AbstractVGen.cpp
@@ -4,10 +4,12 @@
 
 namespace scin { namespace base {
 
-AbstractVGen::AbstractVGen(const std::string& name, bool isSampler, const std::vector<std::string>& inputs,
-                           const std::vector<std::string>& outputs, const std::vector<std::vector<int>> inputDimensions,
+AbstractVGen::AbstractVGen(const std::string& name, unsigned supportedRates, bool isSampler,
+                           const std::vector<std::string>& inputs, const std::vector<std::string>& outputs,
+                           const std::vector<std::vector<int>> inputDimensions,
                            const std::vector<std::vector<int>> outputDimensions, const std::string& shader):
     m_name(name),
+    m_supportedRates(supportedRates),
     m_isSampler(isSampler),
     m_inputs(inputs),
     m_outputs(outputs),

--- a/src/base/AbstractVGen.hpp
+++ b/src/base/AbstractVGen.hpp
@@ -18,12 +18,16 @@ namespace scin { namespace base {
  */
 class AbstractVGen {
 public:
+    /*! Bitflags to indicate supported rates for this VGen.
+     */
+    enum Rates : unsigned { kFrame = 1, kShape = 2, kPixel = 4 };
+
     /*! Construct an AbstractVGen with all required and optional data.
      *
      * \param name The name to use for this VGen, must be unique.
      * \param isSampler If true indicates this is a sampling VGen
      * \param inputs A list of input names, can be empty.
-     * \param ouptuts A list of output names, must be at least one.
+     * \param outputs A list of output names, must be at least one.
      * \param inputDimensions Each subarray describes the allowable dimensions of the input at that index, and so should
      *        have the same number of entries as the number of inputs to the VGen. There should be the same number of
      *        subarrays in inputDimensions as there are in outputDimensions, and the values at each index of both arrays
@@ -33,8 +37,9 @@ public:
      *        with inputDimesion.
      * \param shader The template shader code.
      */
-    AbstractVGen(const std::string& name, bool isSampler, const std::vector<std::string>& inputs,
-                 const std::vector<std::string>& outputs, const std::vector<std::vector<int>> inputDimensions,
+    AbstractVGen(const std::string& name, unsigned supportedRates, bool isSampler,
+                 const std::vector<std::string>& inputs, const std::vector<std::string>& outputs,
+                 const std::vector<std::vector<int>> inputDimensions,
                  const std::vector<std::vector<int>> outputDimensions, const std::string& shader);
     ~AbstractVGen();
 
@@ -61,6 +66,7 @@ public:
                              const std::unordered_set<std::string>& alreadyDefined) const;
 
     const std::string& name() const { return m_name; }
+    unsigned supportedRates() const { return m_supportedRates; }
     bool isSampler() const { return m_isSampler; }
     const std::vector<std::string>& inputs() const { return m_inputs; }
     const std::unordered_set<Intrinsic>& intrinsics() const { return m_intrinsics; }
@@ -84,6 +90,7 @@ private:
     };
 
     std::string m_name;
+    unsigned m_supportedRates;
     bool m_isSampler;
     std::vector<std::string> m_inputs;
     std::vector<std::string> m_outputs;

--- a/src/base/AbstractVGen.hpp
+++ b/src/base/AbstractVGen.hpp
@@ -20,7 +20,7 @@ class AbstractVGen {
 public:
     /*! Bitflags to indicate supported rates for this VGen.
      */
-    enum Rates : unsigned { kFrame = 1, kShape = 2, kPixel = 4 };
+    enum Rates : unsigned { kNone = 0, kFrame = 1, kShape = 2, kPixel = 4 };
 
     /*! Construct an AbstractVGen with all required and optional data.
      *

--- a/src/base/AbstractVGen_unittests.cpp
+++ b/src/base/AbstractVGen_unittests.cpp
@@ -9,37 +9,42 @@
 namespace scin { namespace base {
 
 TEST(AbstractVGenTest, DuplicateParameterNames) {
-    AbstractVGen dupIn("dupIn", false, { "in1", "in1" }, { "out" }, { { 1, 1 } }, { { 1 } }, "@out = @in1 + @in1;");
+    AbstractVGen dupIn("dupIn", scin::base::AbstractVGen::Rates::kPixel, false, { "in1", "in1" }, { "out" },
+                       { { 1, 1 } }, { { 1 } }, "@out = @in1 + @in1;");
     EXPECT_FALSE(dupIn.prepareTemplate());
     EXPECT_FALSE(dupIn.valid());
 
-    AbstractVGen dupOut("dupOut", false, {}, { "out", "out" }, { {} }, { { 1, 1 } }, "@out = 2.0f;");
+    AbstractVGen dupOut("dupOut", scin::base::AbstractVGen::Rates::kPixel, false, {}, { "out", "out" }, { {} },
+                        { { 1, 1 } }, "@out = 2.0f;");
     EXPECT_FALSE(dupOut.prepareTemplate());
     EXPECT_FALSE(dupOut.valid());
 
-    AbstractVGen inCrossOut("inCrossOut", false, { "cross" }, { "cross" }, { { 1 } }, { { 1 } }, "@cross = @cross;");
+    AbstractVGen inCrossOut("inCrossOut", scin::base::AbstractVGen::Rates::kPixel, false, { "cross" }, { "cross" },
+                            { { 1 } }, { { 1 } }, "@cross = @cross;");
     EXPECT_FALSE(inCrossOut.prepareTemplate());
     EXPECT_FALSE(inCrossOut.valid());
 }
 
 TEST(AbstractVGenTest, ReservedParameterNames) {
-    AbstractVGen timeInput("timeInput", false, { "time" }, { "out" }, { { 1 } }, { { 1 } }, "@out = @time;");
+    AbstractVGen timeInput("timeInput", scin::base::AbstractVGen::Rates::kPixel, false, { "time" }, { "out" },
+                           { { 1 } }, { { 1 } }, "@out = @time;");
     EXPECT_FALSE(timeInput.prepareTemplate());
     EXPECT_FALSE(timeInput.valid());
 }
 
 TEST(AbstractVGenTest, UnknownParameterNames) {
-    AbstractVGen noInputParams("noParams", false, {}, { "out" }, { {} }, { { 1 } },
-                               "@out = sin(@freq * 2 * pi * @time);");
+    AbstractVGen noInputParams("noParams", scin::base::AbstractVGen::Rates::kPixel, false, {}, { "out" }, { {} },
+                               { { 1 } }, "@out = sin(@freq * 2 * pi * @time);");
     EXPECT_FALSE(noInputParams.prepareTemplate());
     EXPECT_FALSE(noInputParams.valid());
 
-    AbstractVGen absentInputParam("absentiInputParam", false, { "a" }, { "out" }, { { 1, 1 } }, { { 1 } },
-                                  "@out = @time * (@a + @b);");
+    AbstractVGen absentInputParam("absentiInputParam", scin::base::AbstractVGen::Rates::kPixel, false, { "a" },
+                                  { "out" }, { { 1, 1 } }, { { 1 } }, "@out = @time * (@a + @b);");
     EXPECT_FALSE(absentInputParam.prepareTemplate());
     EXPECT_FALSE(absentInputParam.valid());
 
-    AbstractVGen noOutputParam("absentOutputParam", false, { "a" }, {}, { { 1 } }, { {} }, "@out = 1.0f;");
+    AbstractVGen noOutputParam("absentOutputParam", scin::base::AbstractVGen::Rates::kPixel, false, { "a" }, {},
+                               { { 1 } }, { {} }, "@out = 1.0f;");
     EXPECT_FALSE(noOutputParam.prepareTemplate());
     EXPECT_FALSE(noOutputParam.valid());
 }
@@ -47,32 +52,34 @@ TEST(AbstractVGenTest, UnknownParameterNames) {
 TEST(AbstractVGenTest, DimensionMismatches) {}
 
 TEST(AbstractVGenTest, ParameterizeInvalid) {
-    AbstractVGen invalid("invalid", false, {}, {}, {}, {}, "@out = 1.0f;");
+    AbstractVGen invalid("invalid", scin::base::AbstractVGen::Rates::kPixel, false, {}, {}, {}, {}, "@out = 1.0f;");
     EXPECT_FALSE(invalid.prepareTemplate());
     EXPECT_FALSE(invalid.valid());
     EXPECT_EQ("", invalid.parameterize({}, {}, {}, {}, {}));
 
-    AbstractVGen mismatch("mistmatchInput", false, { "in1", "in2" }, { "out" }, { { 1, 1 } }, { { 1 } },
-                          "@out = @in1 + @in2 / 2.0;");
+    AbstractVGen mismatch("mistmatchInput", scin::base::AbstractVGen::Rates::kPixel, false, { "in1", "in2" }, { "out" },
+                          { { 1, 1 } }, { { 1 } }, "@out = @in1 + @in2 / 2.0;");
     EXPECT_TRUE(mismatch.prepareTemplate());
     EXPECT_TRUE(mismatch.valid());
     EXPECT_EQ("", mismatch.parameterize({ "onlyOne" }, {}, { "out" }, {}, {}));
 }
 
 TEST(AbstractVGenTest, ParameterizeValid) {
-    AbstractVGen constant("constant", false, {}, { "out" }, { {} }, { { 1 } }, "@out = 2.0f;");
+    AbstractVGen constant("constant", scin::base::AbstractVGen::Rates::kPixel, false, {}, { "out" }, { {} }, { { 1 } },
+                          "@out = 2.0f;");
     EXPECT_TRUE(constant.prepareTemplate());
     EXPECT_TRUE(constant.valid());
     EXPECT_EQ("float subOut = 2.0f;", constant.parameterize({}, {}, { "subOut" }, { 1 }, {}));
 
-    AbstractVGen passthrough("passthrough", false, { "in" }, { "out" }, { { 1 } }, { { 1 } }, "@out = @in;");
+    AbstractVGen passthrough("passthrough", scin::base::AbstractVGen::Rates::kPixel, false, { "in" }, { "out" },
+                             { { 1 } }, { { 1 } }, "@out = @in;");
     EXPECT_TRUE(passthrough.prepareTemplate());
     EXPECT_TRUE(passthrough.valid());
     EXPECT_EQ("float passthrough_11_out = passthrough_11_in;",
               passthrough.parameterize({ "passthrough_11_in" }, {}, { "passthrough_11_out" }, { 1 }, {}));
 
-    AbstractVGen moreComplex("moreComplex", false, { "freq", "phase", "mul", "add" }, { "out" }, { { 1, 1, 1, 1 } },
-                             { { 4 } },
+    AbstractVGen moreComplex("moreComplex", scin::base::AbstractVGen::Rates::kPixel, false,
+                             { "freq", "phase", "mul", "add" }, { "out" }, { { 1, 1, 1, 1 } }, { { 4 } },
                              "float temp = @add + @mul * (sin((@time * 2.0 * pi * @freq) + @phase));\n"
                              "@out = float4(temp, temp, temp, 1.0);\n");
     EXPECT_TRUE(moreComplex.prepareTemplate());

--- a/src/base/Archetypes.cpp
+++ b/src/base/Archetypes.cpp
@@ -197,9 +197,27 @@ Archetypes::extractFromNodes(const std::vector<YAML::Node>& nodes) {
                 break;
             }
 
-            // TODO: parse rate key
+            AbstractVGen::Rates rate = AbstractVGen::Rates::kNone;
+            if (!vgen["rate"] || !vgen["rate"].IsScalar()) {
+                spdlog::error("ScinthDef {} has VGen with className {} absent or malformed rate key.", name, className);
+                parseError = true;
+                break;
+            }
+            std::string rateName = vgen["rate"].as<std::string>();
+            if (rateName == "pixel") {
+                rate = AbstractVGen::Rates::kPixel;
+            } else if (rateName == "shape") {
+                rate = AbstractVGen::Rates::kShape;
+            } else if (rateName == "frame") {
+                rate = AbstractVGen::Rates::kFrame;
+            } else {
+                spdlog::error("ScinthDef {} has VGen with className {} with unsupported rate value {}.", name,
+                              className, rateName);
+                parseError = true;
+                break;
+            }
 
-            VGen instance(vgenClass);
+            VGen instance(vgenClass, rate);
 
             if (vgen["sampler"] && vgen["sampler"].IsMap()) {
                 if (!vgenClass->isSampler()) {

--- a/src/base/Archetypes_unittests.cpp
+++ b/src/base/Archetypes_unittests.cpp
@@ -14,12 +14,14 @@ namespace {
 void populateAbstractVGens(std::shared_ptr<scin::base::Archetypes> parser) {
     parser->parseAbstractVGensFromString("---\n"
                                          "name: NoInput\n"
+                                         "rates: [ pixel ]\n"
                                          "outputs: [ out ]\n"
                                          "dimensions:\n"
                                          "  - outputs: 1\n"
                                          "shader: \"@out = 1.0f;\"\n"
                                          "---\n"
                                          "name: OneInput\n"
+                                         "rates: [ pixel ]\n"
                                          "inputs:\n"
                                          "  - a\n"
                                          "outputs:\n"
@@ -30,6 +32,7 @@ void populateAbstractVGens(std::shared_ptr<scin::base::Archetypes> parser) {
                                          "shader: \"@out = @a;\"\n"
                                          "---\n"
                                          "name: TwoInput\n"
+                                         "rates: [ pixel ]\n"
                                          "inputs:\n"
                                          "  - a\n"
                                          "  - b\n"
@@ -41,6 +44,7 @@ void populateAbstractVGens(std::shared_ptr<scin::base::Archetypes> parser) {
                                          "shader: \"@out = @a * @b;\"\n"
                                          "---\n"
                                          "name: ThreeInput\n"
+                                         "rates: [ pixel ]\n"
                                          "inputs: [a, b, c]\n"
                                          "outputs: [ out ]\n"
                                          "dimensions:\n"
@@ -73,11 +77,13 @@ TEST(ArchetypesTest, InvalidAbstractVGenYamlStrings) {
     EXPECT_EQ(0,
               parser.parseAbstractVGensFromString("---\n"
                                                   "name: TestBadVGen\n"
+                                                  "rates: [ pixel ]\n"
                                                   "inputs:\n"
                                                   "  - a\n"
                                                   "  - b\n"));
     EXPECT_EQ(0,
               parser.parseAbstractVGensFromString("---\n"
+                                                  "rates: [ pixel ]\n"
                                                   "outputs:\n"
                                                   "  - out\n"
                                                   "shader: \"@out = 1.0;\"\n"));
@@ -89,12 +95,14 @@ TEST(ArchetypesTest, ValidAbstractVGenYamlStrings) {
     EXPECT_EQ(3,
               parser.parseAbstractVGensFromString("---\n"
                                                   "name: JustNameAndFragment\n"
+                                                  "rates: [ pixel ]\n"
                                                   "outputs: [ out ]\n"
                                                   "dimensions:\n"
                                                   "  - outputs: 1\n"
                                                   "shader: \"@out = 1.0;\"\n"
                                                   "---\n"
                                                   "name: AddInput\n"
+                                                  "rates: [ pixel ]\n"
                                                   "inputs: [ a ]\n"
                                                   "outputs: [ out ]\n"
                                                   "dimensions:\n"
@@ -103,6 +111,7 @@ TEST(ArchetypesTest, ValidAbstractVGenYamlStrings) {
                                                   "shader: \"@out = @a;\"\n"
                                                   "---\n"
                                                   "name: Overwrite\n"
+                                                  "rates: [ pixel ]\n"
                                                   "outputs: [ out ]\n"
                                                   "dimensions:\n"
                                                   "  - outputs: 1\n"
@@ -128,6 +137,7 @@ TEST(ArchetypesTest, ValidAbstractVGenYamlStrings) {
     EXPECT_EQ(1,
               parser.parseAbstractVGensFromString("---\n"
                                                   "name: Overwrite\n"
+                                                  "rates: [ pixel ]\n"
                                                   "outputs:\n"
                                                   "  - out\n"
                                                   "dimensions:\n"
@@ -144,6 +154,7 @@ TEST(ArchetypesTest, ValidAbstractVGenYamlStrings) {
     EXPECT_EQ(1,
               parser.parseAbstractVGensFromString("---\n"
                                                   "name: Overwrite\n"
+                                                  "rates: [ frame, shape, pixel ]\n"
                                                   "outputs: [ out ]\n"
                                                   "dimensions:\n"
                                                   "  - outputs: [ 1 ]\n"
@@ -152,6 +163,8 @@ TEST(ArchetypesTest, ValidAbstractVGenYamlStrings) {
     overwrite = parser.getAbstractVGenNamed("Overwrite");
     ASSERT_TRUE(overwrite);
     EXPECT_EQ("Overwrite", overwrite->name());
+    EXPECT_EQ(AbstractVGen::Rates::kFrame | AbstractVGen::Rates::kShape | AbstractVGen::Rates::kPixel,
+              overwrite->supportedRates());
     EXPECT_EQ(0, overwrite->intrinsics().size());
     EXPECT_EQ("float fl = 2.0; @out = fl;", overwrite->shader());
 }
@@ -172,6 +185,7 @@ TEST(ArchetypesTest, ParseAbstractVGenFromFile) {
     clobberFileWithString(tempFile,
                           "---\n"
                           "name: FileVGen\n"
+                          "rates: [ pixel ]\n"
                           "outputs: [ out ]\n"
                           "dimensions:\n"
                           "  - outputs: [ 1 ]\n"
@@ -196,7 +210,7 @@ TEST(ArchetypesTest, InvalidYAMLStrings) {
               parser
                   ->parseFromString("vgens:\n"
                                     "  - className: NoInput\n"
-                                    "    rate: fragment\n")
+                                    "    rate: pixel\n")
                   .size());
     // The vgens key has to be a sequence.
     EXPECT_EQ(0,
@@ -212,7 +226,7 @@ TEST(ArchetypesTest, InvalidYAMLStrings) {
                                     "name: missingVGen\n"
                                     "vgens:\n"
                                     "  - className: NotFound\n"
-                                    "    rate: fragment\n")
+                                    "    rate: pixel\n")
                   .size());
 
     // The vgen must have the correct number of inputs.
@@ -221,7 +235,7 @@ TEST(ArchetypesTest, InvalidYAMLStrings) {
                   ->parseFromString("name: wrongInputsVGen\n"
                                     "vgens:\n"
                                     "  - className: NoInput\n"
-                                    "    rate: fragment\n"
+                                    "    rate: pixel\n"
                                     "    inputs:\n"
                                     "      - type: constant\n"
                                     "        value: 200.0\n")
@@ -233,7 +247,7 @@ TEST(ArchetypesTest, InvalidYAMLStrings) {
                   ->parseFromString("name: badVGenInputsOrder\n"
                                     "vgens:\n"
                                     "  - className: OneInput\n"
-                                    "    rate: fragment\n"
+                                    "    rate: pixel\n"
                                     "    inputs:\n"
                                     "      - type: vgen\n"
                                     "        vgenIndex: 1\n")
@@ -252,7 +266,7 @@ TEST(ArchetypesTest, ValidYAMLStrings) {
                                     "name: firstScinth\n"
                                     "vgens:\n"
                                     "  - className: NoInput\n"
-                                    "    rate: fragment\n"
+                                    "    rate: pixel\n"
                                     "    outputs:\n"
                                     "      - dimension: 1\n")
                   .size());
@@ -268,7 +282,7 @@ TEST(ArchetypesTest, ValidYAMLStrings) {
                                     "name: firstScinth\n"
                                     "vgens:\n"
                                     "  - className: OneInput\n"
-                                    "    rate: fragment\n"
+                                    "    rate: pixel\n"
                                     "    inputs:\n"
                                     "      - type: constant\n"
                                     "        dimension: 1\n"
@@ -276,7 +290,7 @@ TEST(ArchetypesTest, ValidYAMLStrings) {
                                     "    outputs:\n"
                                     "      - dimension: 1\n"
                                     "  - className: TwoInput\n"
-                                    "    rate: fragment\n"
+                                    "    rate: pixel\n"
                                     "    inputs:\n"
                                     "      - type: vgen\n"
                                     "        dimension: 1\n"
@@ -291,7 +305,7 @@ TEST(ArchetypesTest, ValidYAMLStrings) {
                                     "name: secondScinth\n"
                                     "vgens: \n"
                                     "  - className: ThreeInput\n"
-                                    "    rate: fragment\n"
+                                    "    rate: pixel\n"
                                     "    inputs: \n"
                                     "      - type: constant\n"
                                     "        dimension: 1\n"

--- a/src/base/VGen.cpp
+++ b/src/base/VGen.cpp
@@ -1,12 +1,12 @@
 #include "base/VGen.hpp"
 
-#include "base/AbstractVGen.hpp"
-
 #include "spdlog/spdlog.h"
 
 namespace scin { namespace base {
 
-VGen::VGen(std::shared_ptr<const AbstractVGen> abstractVGen): m_abstractVGen(abstractVGen) {}
+VGen::VGen(std::shared_ptr<const AbstractVGen> abstractVGen, AbstractVGen::Rates rate):
+    m_abstractVGen(abstractVGen),
+    m_rate(rate) {}
 
 VGen::~VGen() {}
 
@@ -33,6 +33,11 @@ bool VGen::validate() const {
     if (m_inputs.size() != m_abstractVGen->inputs().size()) {
         spdlog::error("input size mismatch for VGen {}, expected {}, got {}", m_abstractVGen->name(),
                       m_abstractVGen->inputs().size(), m_inputs.size());
+        return false;
+    }
+
+    if ((m_rate & m_abstractVGen->supportedRates()) == 0) {
+        spdlog::error("Unsupported rate for VGen {}", m_abstractVGen->name());
         return false;
     }
 

--- a/src/base/VGen.hpp
+++ b/src/base/VGen.hpp
@@ -2,6 +2,7 @@
 #define SRC_CORE_VGEN_HPP_
 
 #include "base/AbstractSampler.hpp"
+#include "base/AbstractVGen.hpp"
 
 #include <memory>
 #include <vector>
@@ -10,13 +11,11 @@
 
 namespace scin { namespace base {
 
-class AbstractVGen;
-
 /*! Represents a single node in the signal flow graph of a ScinthDef. Combines an AbstractVGen and inputs.
  */
 class VGen {
 public:
-    VGen(std::shared_ptr<const AbstractVGen> abstractVGen);
+    VGen(std::shared_ptr<const AbstractVGen> abstractVGen, AbstractVGen::Rates rate);
     ~VGen();
 
     enum InputType { kConstant, kVGen, kParameter, kInvalid };
@@ -104,6 +103,7 @@ public:
     int outputDimension(int index) const { return m_outputDimensions[index]; }
 
     std::shared_ptr<const AbstractVGen> abstractVGen() const { return m_abstractVGen; }
+    AbstractVGen::Rates rate() const { return m_rate; }
 
     int imageIndex() const { return m_imageIndex; }
     InputType imageArgType() const { return m_imageArgType; }
@@ -134,6 +134,7 @@ private:
     };
 
     std::shared_ptr<const AbstractVGen> m_abstractVGen;
+    AbstractVGen::Rates m_rate;
     int m_imageIndex;
     InputType m_imageArgType;
     AbstractSampler m_abstractSampler;

--- a/src/base/VGen_unittests.cpp
+++ b/src/base/VGen_unittests.cpp
@@ -10,14 +10,14 @@ TEST(VGenTest, InvalidInputCounts) {
     std::shared_ptr<const AbstractVGen> noInputs(new AbstractVGen("noInput", scin::base::AbstractVGen::Rates::kPixel,
                                                                   false, {}, { "out" }, { {} }, { { 1 } },
                                                                   "@out = @time * 0.5f;"));
-    VGen someInputs(noInputs);
+    VGen someInputs(noInputs, AbstractVGen::Rates::kPixel);
     someInputs.addConstantInput(1.0f);
     EXPECT_FALSE(someInputs.validate());
 
     std::shared_ptr<const AbstractVGen> twoInputs(new AbstractVGen("twoInputs", scin::base::AbstractVGen::Rates::kPixel,
                                                                    false, { "in1", "in2" }, { "out" }, { { 1, 1 } },
                                                                    { { 1 } }, "@out = @in1 + @in2;"));
-    VGen incrementalInputs(twoInputs);
+    VGen incrementalInputs(twoInputs, AbstractVGen::Rates::kPixel);
     EXPECT_FALSE(incrementalInputs.validate());
     incrementalInputs.addVGenInput(0, 0, 1);
     EXPECT_FALSE(incrementalInputs.validate());
@@ -27,11 +27,19 @@ TEST(VGenTest, InvalidInputCounts) {
     EXPECT_FALSE(incrementalInputs.validate());
 }
 
+TEST(VGenTest, InvalidRate) {
+    std::shared_ptr<const AbstractVGen> frameRateOnly(
+        new AbstractVGen("frameRateOnly", scin::base::AbstractVGen::Rates::kFrame, false, {}, { "out" }, { {} },
+                         { { 1 } }, "@out = 25.0;"));
+    VGen pixelRate(frameRateOnly, AbstractVGen::Rates::kPixel);
+    EXPECT_FALSE(pixelRate.validate());
+}
+
 TEST(VGenTest, InputValuesAndTypesRetained) {
     std::shared_ptr<const AbstractVGen> threeInputs(
         new AbstractVGen("threeInputs", scin::base::AbstractVGen::Rates::kPixel, false, { "a", "b", "c" }, { "out" },
                          { { 1, 1, 1 } }, { { 1 } }, "@out = @a + @b + @c;"));
-    VGen allConstants(threeInputs);
+    VGen allConstants(threeInputs, AbstractVGen::Rates::kPixel);
     allConstants.addConstantInput(-1.0f);
     allConstants.addConstantInput(2.0f);
     allConstants.addConstantInput(45.0f);
@@ -63,7 +71,7 @@ TEST(VGenTest, InputValuesAndTypesRetained) {
     EXPECT_EQ(0, outputIndex);
     EXPECT_TRUE(allConstants.validate());
 
-    VGen allVGens(threeInputs);
+    VGen allVGens(threeInputs, AbstractVGen::Rates::kPixel);
     allVGens.addVGenInput(2, 1, 1);
     allVGens.addVGenInput(3, 4, 2);
     allVGens.addVGenInput(0, 0, 3);
@@ -98,7 +106,7 @@ TEST(VGenTest, InputValuesAndTypesRetained) {
     EXPECT_EQ(-2, outputIndex);
     EXPECT_TRUE(allVGens.validate());
 
-    VGen pickAndMix(threeInputs);
+    VGen pickAndMix(threeInputs, AbstractVGen::Rates::kPixel);
     pickAndMix.addConstantInput(-23.7f);
     pickAndMix.addVGenInput(14, 7, 3);
     pickAndMix.addConstantInput(12224.3);

--- a/src/base/VGen_unittests.cpp
+++ b/src/base/VGen_unittests.cpp
@@ -7,14 +7,16 @@
 namespace scin { namespace base {
 
 TEST(VGenTest, InvalidInputCounts) {
-    std::shared_ptr<const AbstractVGen> noInputs(
-        new AbstractVGen("noInput", false, {}, { "out" }, { {} }, { { 1 } }, "@out = @time * 0.5f;"));
+    std::shared_ptr<const AbstractVGen> noInputs(new AbstractVGen("noInput", scin::base::AbstractVGen::Rates::kPixel,
+                                                                  false, {}, { "out" }, { {} }, { { 1 } },
+                                                                  "@out = @time * 0.5f;"));
     VGen someInputs(noInputs);
     someInputs.addConstantInput(1.0f);
     EXPECT_FALSE(someInputs.validate());
 
-    std::shared_ptr<const AbstractVGen> twoInputs(new AbstractVGen("twoInputs", false, { "in1", "in2" }, { "out" },
-                                                                   { { 1, 1 } }, { { 1 } }, "@out = @in1 + @in2;"));
+    std::shared_ptr<const AbstractVGen> twoInputs(new AbstractVGen("twoInputs", scin::base::AbstractVGen::Rates::kPixel,
+                                                                   false, { "in1", "in2" }, { "out" }, { { 1, 1 } },
+                                                                   { { 1 } }, "@out = @in1 + @in2;"));
     VGen incrementalInputs(twoInputs);
     EXPECT_FALSE(incrementalInputs.validate());
     incrementalInputs.addVGenInput(0, 0, 1);
@@ -26,8 +28,9 @@ TEST(VGenTest, InvalidInputCounts) {
 }
 
 TEST(VGenTest, InputValuesAndTypesRetained) {
-    std::shared_ptr<const AbstractVGen> threeInputs(new AbstractVGen(
-        "threeInputs", false, { "a", "b", "c" }, { "out" }, { { 1, 1, 1 } }, { { 1 } }, "@out = @a + @b + @c;"));
+    std::shared_ptr<const AbstractVGen> threeInputs(
+        new AbstractVGen("threeInputs", scin::base::AbstractVGen::Rates::kPixel, false, { "a", "b", "c" }, { "out" },
+                         { { 1, 1, 1 } }, { { 1 } }, "@out = @a + @b + @c;"));
     VGen allConstants(threeInputs);
     allConstants.addConstantInput(-1.0f);
     allConstants.addConstantInput(2.0f);

--- a/tests/TestScinthDef.sc
+++ b/tests/TestScinthDef.sc
@@ -83,7 +83,7 @@ TestScinthDef : UnitTest {
 
 	test_singleVgenBuild {
 		var def = ScinthDef.new(\singleVgenBuild, {
-			BWOut.fr(1.0);
+			BWOut.pr(1.0);
 		});
 
 		this.sanityCheckBuild(def);
@@ -99,7 +99,7 @@ TestScinthDef : UnitTest {
 
 	test_inputChainLinearBuild {
 		var def = ScinthDef.new(\inputChainLinearBuild, {
-			BWOut.fr(VSinOsc.fr.abs);
+			BWOut.pr(VSinOsc.pr.abs);
 		});
 
 		this.sanityCheckBuild(def);
@@ -116,7 +116,7 @@ TestScinthDef : UnitTest {
 
 	test_singleVgenYaml {
 		var def = ScinthDef.new(\singleVgenYaml, {
-			BWOut.fr(1.0.neg);
+			BWOut.pr(1.0.neg);
 		});
 		var yaml = def.asYAML;
 
@@ -126,8 +126,8 @@ TestScinthDef : UnitTest {
 
 	test_inputChainYaml {
 		var def = ScinthDef.new(\inputChainYaml, {
-			var pos = NormPos.fr;
-			BWOut.fr(VSinOsc.fr(freq: VY.fr(pos).neg, phase: VX.fr(pos), mul: 0.2, add: 0.5));
+			var pos = NormPos.pr;
+			BWOut.pr(VSinOsc.pr(freq: VY.pr(pos).neg, phase: VX.pr(pos), mul: 0.2, add: 0.5));
 		});
 		var yaml = def.asYAML;
 
@@ -137,8 +137,8 @@ TestScinthDef : UnitTest {
 
 	test_paramsNoValues {
 		var def = ScinthDef.new(\paramsNoValues, { |a, b, c|
-			var sin3 = Vec3.fr(a, b, c).sin;
-			RGBOut.fr(VX.fr(sin3), VY.fr(sin3), VZ.fr(sin3));
+			var sin3 = Vec3.pr(a, b, c).sin;
+			RGBOut.pr(VX.pr(sin3), VY.pr(sin3), VZ.pr(sin3));
 		});
 		// Make sure names are in correct order and all represented.
 		this.assertEquals(3, def.controlNames.size);
@@ -158,7 +158,7 @@ TestScinthDef : UnitTest {
 	test_paramsMixedValues {
 		var def = ScinthDef.new(\paramsValues, { |quick = 10.0, slow = 0.001, x = -17|
 			var average = quick + slow / 2;
-			BWOut.fr(average - x);
+			BWOut.pr(average - x);
 		});
 		this.assertEquals(3, def.controlNames.size);
 		this.assertEquals('quick', def.controlNames[0]);
@@ -179,7 +179,7 @@ TestScinthDef : UnitTest {
 
 		try {
 			ScinthDef(\vgen_nilIsInvalid, {
-				BWOut.fr(nil);
+				BWOut.pr(nil);
 			});
 		} { | e |
 			err = e;
@@ -195,7 +195,7 @@ TestScinthDef : UnitTest {
 
 		try {
 			ScinthDef(\vgen_nilIsInvalid, {
-				BWOut.fr(SinOsc.ar());
+				BWOut.pr(SinOsc.ar());
 			});
 		} { | e |
 			err = e;

--- a/tools/TestScripts/oscTest.scd
+++ b/tools/TestScripts/oscTest.scd
@@ -284,7 +284,7 @@ fork {
 	c.test = false;
 	d.test = false;
 	valid = false;
-	testDef = ScinthDef.new(\t, { BWOut.fr(1.0); });
+	testDef = ScinthDef.new(\t, { BWOut.pr(1.0); });
 	response = OSCFunc.new({ |msg|
 		c.test = true;
 		c.signal;

--- a/tools/TestScripts/testDefs/t1-2.yaml
+++ b/tools/TestScripts/testDefs/t1-2.yaml
@@ -1,7 +1,7 @@
 name: t1
 vgens:
     - className: RGBOut
-      rate: fragment
+      rate: pixel
       inputs:
         - type: constant
           dimension: 1
@@ -18,11 +18,11 @@ vgens:
 name: t2
 vgens:
     - className: NormPos
-      rate: fragment
+      rate: pixel
       outputs:
         - dimension: 2
     - className: Length
-      rate: fragment
+      rate: pixel
       inputs:
         - type: vgen
           vgenIndex: 0
@@ -31,7 +31,7 @@ vgens:
       outputs:
         - dimension: 1
     - className: VSaw
-      rate: fragment
+      rate: pixel
       inputs:
         - type: constant
           dimension: 1
@@ -43,7 +43,7 @@ vgens:
       outputs:
         - dimension: 1
     - className: VSinOsc
-      rate: fragment
+      rate: pixel
       inputs:
         - type: vgen
           vgenIndex: 1
@@ -62,7 +62,7 @@ vgens:
       outputs:
         - dimension: 1
     - className: RGBOut
-      rate: fragment
+      rate: pixel
       inputs:
         - type: vgen
           vgenIndex: 1

--- a/tools/TestScripts/testDefs/t3.yaml
+++ b/tools/TestScripts/testDefs/t3.yaml
@@ -1,11 +1,11 @@
 name: t3
 vgens:
     - className: NormPos
-      rate: fragment
+      rate: pixel
       outputs:
         - dimension: 2
     - className: Length
-      rate: fragment
+      rate: pixel
       inputs:
         - type: vgen
           vgenIndex: 0
@@ -14,7 +14,7 @@ vgens:
       outputs:
         - dimension: 1
     - className: BWOut
-      rate: fragment
+      rate: pixel
       inputs:
         - type: vgen
           vgenIndex: 1

--- a/tools/TestScripts/testManifest.yaml
+++ b/tools/TestScripts/testManifest.yaml
@@ -8,15 +8,15 @@
   category: "VOsc"
   comment: "VSinOsc frequency as a function of distance from center."
   shortName: "scinOsc"
-  scinthDef: "{ BWOut.fr(VSinOsc.fr(Length.fr(NormPos.fr))); }"
+  scinthDef: "{ BWOut.pr(VSinOsc.pr(Length.pr(NormPos.pr))); }"
   captureTimes: [ 1, 1, 1, 1, 1 ]
 - name: "VSaw Checker"
   category: "VOsc"
   comment: "VSaw two color checker pattern."
   shortName: "gingham"
   scinthDef: "{
-    var pos = NormPos.fr;
-    RGBOut.fr(VSaw.fr(1.0, VX.fr(pos)), VSaw.fr(1.5, VY.fr(pos)), VSaw.fr(VX.fr(NormPos.fr)));
+    var pos = NormPos.pr;
+    RGBOut.pr(VSaw.pr(1.0, VX.pr(pos)), VSaw.pr(1.5, VY.pr(pos)), VSaw.pr(VX.pr(NormPos.pr)));
   }"
   captureTimes: [ 1, 1 ]
 - name: "Param Colors"
@@ -24,7 +24,7 @@
   comment: "Test default values of parameters and a simple change"
   shortName: "paramColors"
   scinthDef: "{ |r = 0.5, g = 0.1, b = 0.9|
-    RGBOut.fr(r, g, b);
+    RGBOut.pr(r, g, b);
   }"
   captureTimes: [ 1, 1, 1 ]
   parameters:
@@ -37,10 +37,10 @@
   comment: "Test parameters on a more complex ScinthDef"
   shortName: "paramParab"
   scinthDef: "{ |scale=2.0, xmod=0.5, ymod=0.5|
-    var pos = NormPos.fr() * scale;
-    var sawA = VSaw.fr(0.7, (VX.fr(pos) % xmod) * VY.fr(pos));
-    var sawB = VSaw.fr(0.9, VX.fr(pos) * (VY.fr(pos) % ymod));
-    BWOut.fr(sawA * sawB);
+    var pos = NormPos.pr() * scale;
+    var sawA = VSaw.pr(0.7, (VX.pr(pos) % xmod) * VY.pr(pos));
+    var sawB = VSaw.pr(0.9, VX.pr(pos) * (VY.pr(pos) % ymod));
+    BWOut.pr(sawA * sawB);
   }"
   captureTimes: [ 1, 1, 1 ]
   parameters:
@@ -54,11 +54,11 @@
   comment: "Test simple image render with constant image"
   shortName: "constImage"
   scinthDef: "{
-    var size = TextureSize.fr(1);
-    var aspect = VX.fr(size) / VY.fr(size);
-    var pos = TexPos.fr;
-    pos = Vec2.fr((VX.fr(pos) - 0.125) / aspect, VY.fr(pos));
-    Sampler.fr(1, pos); }"
+    var size = TextureSize.pr(1);
+    var aspect = VX.pr(size) / VY.pr(size);
+    var pos = TexPos.pr;
+    pos = Vec2.pr((VX.pr(pos) - 0.125) / aspect, VY.pr(pos));
+    Sampler.pr(1, pos); }"
   images:
     - file: "molly.png"
       number: 1
@@ -68,11 +68,11 @@
   comment: "Test simple image render with parameterized image"
   shortName: "paramImage"
   scinthDef: "{ |i|
-    var size = TextureSize.fr(i);
-    var aspect = VX.fr(size) / VY.fr(size);
-    var pos = TexPos.fr;
-    pos = Vec2.fr((VX.fr(pos) - 0.125) / aspect, VY.fr(pos));
-    Sampler.fr(i, pos);
+    var size = TextureSize.pr(i);
+    var aspect = VX.pr(size) / VY.pr(size);
+    var pos = TexPos.pr;
+    pos = Vec2.pr((VX.pr(pos) - 0.125) / aspect, VY.pr(pos));
+    Sampler.pr(i, pos);
   }"
   images:
     - file: "storm.png"
@@ -89,7 +89,7 @@
   category: "images"
   comment: "Test sampler border mode clamp with a white border"
   shortName: "whiteBorder"
-  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).clampBorderColor_('white'); }"
+  scinthDef: "{ Sampler.pr(1, TexPos.pr * 3.0).clampBorderColor_('white'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -98,7 +98,7 @@
   category: "images"
   comment: "Test sampler with border mode clamp with an opaque black border"
   shortName: "blackBorder"
-  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).clampBorderColor_('black'); }"
+  scinthDef: "{ Sampler.pr(1, TexPos.pr * 3.0).clampBorderColor_('black'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -107,7 +107,7 @@
   category: "images"
   comment: "Test sampler with clamp to edge border mode"
   shortName: "edgeBorder"
-  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).addressMode('clampToEdge'); }"
+  scinthDef: "{ Sampler.pr(1, TexPos.pr * 3.0).addressMode('clampToEdge'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -116,7 +116,7 @@
   category: "images"
   comment: "Test sampler with repeat border mode"
   shortName: "repeatBorder"
-  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).addressMode('repeat'); }"
+  scinthDef: "{ Sampler.pr(1, TexPos.pr * 3.0).addressMode('repeat'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -125,7 +125,7 @@
   category: "images"
   comment: "Test sampler with repeat border mode"
   shortName: "mirrorBorder"
-  scinthDef: "{ Sampler.fr(1, TexPos.fr * 3.0).addressMode('mirroredRepeat'); }"
+  scinthDef: "{ Sampler.pr(1, TexPos.pr * 3.0).addressMode('mirroredRepeat'); }"
   images:
     - file: "molly.png"
       number: 1
@@ -135,9 +135,9 @@
   comment: "Test providing all forms of parameters to an Scinth"
   shortName: "complexImage"
   scinthDef: "{ |i = 2|
-    var pos = TexPos.fr;
-    var m = Sampler.fr(1, Vec2.fr(VSaw.fr(freq: 0.5, phase: VX.fr(pos)), VSaw.fr(freq: (0.75 / 2.0), phase: VY.fr(pos))));
-    var s = Sampler.fr(i, Vec2.fr(VSaw.fr(freq: 2.0, phase: 1.0 - VX.fr(pos)), VSaw.fr(freq: 1.5, phase: 1.0 - VY.fr(pos))) * 2.0);
+    var pos = TexPos.pr;
+    var m = Sampler.pr(1, Vec2.pr(VSaw.pr(freq: 0.5, phase: VX.pr(pos)), VSaw.pr(freq: (0.75 / 2.0), phase: VY.pr(pos))));
+    var s = Sampler.pr(i, Vec2.pr(VSaw.pr(freq: 2.0, phase: 1.0 - VX.pr(pos)), VSaw.pr(freq: 1.5, phase: 1.0 - VY.pr(pos))) * 2.0);
     s + m;
   }"
   images:
@@ -156,7 +156,7 @@
   comment: "Test alpha blending colors between different Scinths, starting with a white opaque background."
   shortName: "alphaWhite"
   scinthDef: "{
-    BWOut.fr(1.0);
+    BWOut.pr(1.0);
   }"
   captureTimes: [ 1 ]
   keep: true
@@ -165,9 +165,9 @@
   comment: "Add in a green alpha-blended offset circle."
   shortName: "alphaGreen"
   scinthDef: "{
-    var off = Vec2.fr(-0.3, 0.3);
-    var v = Clamp.fr(1.1 - (Length.fr(NormPos.fr - off)), 0.0, 1.0);
-    RGBAOut.fr(0, v, 0, v);
+    var off = Vec2.pr(-0.3, 0.3);
+    var v = Clamp.pr(1.1 - (Length.pr(NormPos.pr - off)), 0.0, 1.0);
+    RGBAOut.pr(0, v, 0, v);
   }"
   captureTimes: [ 1 ]
   keep: true
@@ -176,9 +176,9 @@
   comment: "Now add in a red layer. Note that the generated image is order-dependent."
   shortName: "alphaRed"
   scinthDef: "{
-    var off = Vec2.fr(0.3, 0.3);
-    var v = Clamp.fr(1.1 - (Length.fr(NormPos.fr - off)), 0.0, 1.0);
-    RGBAOut.fr(v, 0, 0, v);
+    var off = Vec2.pr(0.3, 0.3);
+    var v = Clamp.pr(1.1 - (Length.pr(NormPos.pr - off)), 0.0, 1.0);
+    RGBAOut.pr(v, 0, 0, v);
   }"
   captureTimes: [ 1 ]
   keep: true
@@ -187,9 +187,9 @@
   comment: "Add in a blue layer to complete the color wheel."
   shortName: "alphaBlue"
   scinthDef: "{
-    var off = Vec2.fr(0.0, -1.0 * Length.fr(0.3, 0.3));
-    var v = Clamp.fr(1.1 - (Length.fr(NormPos.fr - off)), 0.0, 1.0);
-    RGBAOut.fr(0, 0, v, v);
+    var off = Vec2.pr(0.0, -1.0 * Length.pr(0.3, 0.3));
+    var v = Clamp.pr(1.1 - (Length.pr(NormPos.pr - off)), 0.0, 1.0);
+    RGBAOut.pr(0, 0, v, v);
   }"
   captureTimes: [ 1 ]
   keep: true

--- a/vgens/BasicOpsVGen.yaml
+++ b/vgens/BasicOpsVGen.yaml
@@ -1,6 +1,7 @@
 # Simple arithmetic VGens
 ---    ##### Unary Operations
 name: VNeg
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -15,6 +16,7 @@ dimensions:
 shader: "@out = -1.0f * @a;"
 ---
 name: VAbs
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -29,6 +31,7 @@ dimensions:
 shader: "@out = abs(@a);"
 ---
 name: VCeil
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -43,6 +46,7 @@ dimensions:
 shader: "@out = ceil(@a);"
 ---
 name: VFloor
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -57,6 +61,7 @@ dimensions:
 shader: "@out = floor(@a);"
 ---
 name: VFract
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -71,6 +76,7 @@ dimensions:
 shader: "@out = fract(@a);"
 ---
 name: VSign
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -85,6 +91,7 @@ dimensions:
 shader: "@out = sign(@a);"
 ---
 name: VSqrt
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -99,6 +106,7 @@ dimensions:
 shader: "@out = sqrt(@a);"
 ---
 name: VExp
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -113,6 +121,7 @@ dimensions:
 shader: "@out = exp(@a);"
 ---
 name: VLog
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -127,6 +136,7 @@ dimensions:
 shader: "@out = log(@a);"
 ---
 name: VLog2
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -141,6 +151,7 @@ dimensions:
 shader: "@out = log2(@a);"
 ---
 name: VSin
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -155,6 +166,7 @@ dimensions:
 shader: "@out = sin(@a);"
 ---
 name: VCos
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -169,6 +181,7 @@ dimensions:
 shader: "@out = cos(@a);"
 ---
 name: VTan
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -183,6 +196,7 @@ dimensions:
 shader: "@out = tan(@a);"
 ---
 name: VASin
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -197,6 +211,7 @@ dimensions:
 shader: "@out = asin(@a);"
 ---
 name: VACos
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -211,6 +226,7 @@ dimensions:
 shader: "@out = acos(@a);"
 ---
 name: VATan
+rates: [ frame, shape, pixel ]
 inputs: [ a ]
 outputs: [ out ]
 dimensions:
@@ -225,6 +241,7 @@ dimensions:
 shader: "@out = atan(@a);"
 ---    #### Binary Operations
 name: VAdd
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -239,6 +256,7 @@ dimensions:
 shader: "@out = @a + @b;"
 ---
 name: VSub
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -253,6 +271,7 @@ dimensions:
 shader: "@out = @a - @b;"
 ---
 name: VMul
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -267,6 +286,7 @@ dimensions:
 shader: "@out = @a * @b;"
 ---
 name: VDiv
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -281,6 +301,7 @@ dimensions:
 shader: "@out = @a / @b;"
 ---
 name: VMod
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -295,6 +316,7 @@ dimensions:
 shader: "@out = mod(@a, @b);"
 ---
 name: VPow
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -309,6 +331,7 @@ dimensions:
 shader: "@out = pow(@a, @b);"
 ---
 name: VMin
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -323,6 +346,7 @@ dimensions:
 shader: "@out = min(@a, @b);"
 ---
 name: VMax
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:
@@ -337,6 +361,7 @@ dimensions:
 shader: "@out = max(@a, @b);"
 ---
 name: VATan2
+rates: [ frame, shape, pixel ]
 inputs: [ a, b ]
 outputs: [ out ]
 dimensions:

--- a/vgens/BuiltIn.yaml
+++ b/vgens/BuiltIn.yaml
@@ -1,6 +1,7 @@
 # VGens that wrap GLSL built-in functions or variables. This is not an exhaustive list, adding things as needed.
 ---
 name: Distance
+rates: [ frame, shape, pixel ]
 inputs: [ x, y ]
 outputs: [ out ]
 dimensions:
@@ -15,6 +16,7 @@ dimensions:
 shader: "@out = distance(@x, @y);"
 ---
 name: Dot
+rates: [ frame, shape, pixel ]
 inputs: [ x, y ]
 outputs: [ out ]
 dimensions:
@@ -29,6 +31,7 @@ dimensions:
 shader: "@out = dot(@x, @y);"
 ---
 name: Clamp
+rates: [ frame, shape, pixel ]
 inputs: [ x, min, max ]
 outputs: [ out ]
 dimensions:
@@ -43,6 +46,7 @@ dimensions:
 shader: "@out = clamp(@x, @min, @max);"
 ---
 name: Cross
+rates: [ frame, shape, pixel ]
 inputs: [ x, y ]
 outputs: [ out ]
 dimensions:
@@ -51,12 +55,14 @@ dimensions:
 shader: "@out = cross(@x, @y);"
 ---
 name: FragCoord
+rates: [ frame, shape, pixel ]
 outputs: [ out ]
 dimensions:
     - outputs: 2
 shader: "@out = vec2(@fragCoord.x, @fragCoord.y);"
 ---
 name: Length
+rates: [ frame, shape, pixel ]
 inputs: [ in ]
 outputs: [ out ]
 dimensions:
@@ -71,6 +77,7 @@ dimensions:
 shader: "@out = length(@in);"
 ---
 name: Step
+rates: [ frame, shape, pixel ]
 inputs: [ edge, x ]
 outputs: [ out ]
 dimensions:
@@ -85,6 +92,7 @@ dimensions:
 shader: "@out = step(@edge, @x);"
 ---
 name: TextureSize
+rates: [ frame, shape, pixel ]
 sampler: true
 outputs: [ out ]
 dimensions:
@@ -92,6 +100,7 @@ dimensions:
 shader: "@out = vec2(textureSize(@sampler, 0));"
 ---
 name: VecMix
+rates: [ frame, shape, pixel ]
 inputs: [ x, y, a ]
 outputs: [ out ]
 dimensions:
@@ -112,6 +121,7 @@ dimensions:
 shader: "@out = mix(@x, @y, @a);"
 ---
 name: VNorm
+rates: [ frame, shape, pixel ]
 inputs: [ x ]
 outputs: [ out ]
 dimensions:

--- a/vgens/InOut.yaml
+++ b/vgens/InOut.yaml
@@ -1,5 +1,6 @@
 ---
 name: RGBOut
+rates: [ pixel ]
 inputs:
     - red
     - blue
@@ -12,6 +13,7 @@ dimensions:
 shader: "@rgba = vec4(@red, @blue, @green, 1.0);"
 ---
 name: BWOut
+rates: [ pixel ]
 inputs:
     - value
 outputs:
@@ -22,6 +24,7 @@ dimensions:
 shader: "@rgba = vec4(@value, @value, @value, 1.0);"
 ---
 name: RGBAOut
+rates: [ pixel ]
 inputs:
     - red
     - blue

--- a/vgens/Intrinsics.yaml
+++ b/vgens/Intrinsics.yaml
@@ -1,12 +1,14 @@
 # Direct access to some of the Intrinsics within Scintillator.
 ---
 name: NormPos
+rates: [ shape, pixel ]
 outputs: [ out ]
 dimensions:
     - outputs: 2
 shader: "@out = @normPos;"
 ---
 name: TexPos
+rates: [ shape, pixel ]
 outputs: [ out ]
 dimensions:
     - outputs: 2

--- a/vgens/Sampler.yaml
+++ b/vgens/Sampler.yaml
@@ -1,6 +1,7 @@
 # Image and Video Buffer Input and Output
 ---
 name: Sampler
+rates: [ frame, shape, pixel ]
 sampler: true
 inputs:
     - pos

--- a/vgens/VOsc.yaml
+++ b/vgens/VOsc.yaml
@@ -1,5 +1,6 @@
 ---
 name: VSaw
+rates: [ frame, shape, pixel ]
 inputs:
     - freq
     - phase
@@ -17,6 +18,7 @@ dimensions:
 shader: "@out = fract((@time + @phase) * @freq);"
 ---
 name: VSinOsc
+rates: [ frame, shape, pixel ]
 inputs:
     - freq
     - phase

--- a/vgens/Vectors.yaml
+++ b/vgens/Vectors.yaml
@@ -1,4 +1,5 @@
 name: Vec2
+rates: [ frame, shape, pixel ]
 inputs:
     - x
     - y
@@ -10,6 +11,7 @@ dimensions:
 shader: "@out = vec2(@x, @y);"
 ---
 name: Vec3
+rates: [ frame, shape, pixel ]
 inputs:
     - x
     - y
@@ -22,6 +24,7 @@ dimensions:
 shader: "@out = vec3(@x, @y, @z);"
 ---
 name: Vec4
+rates: [ frame, shape, pixel ]
 inputs:
     - x
     - y
@@ -35,6 +38,7 @@ dimensions:
 shader: "@out = vec4(@x, @y, @z, @w);"
 ---
 name: VX
+rates: [ frame, shape, pixel ]
 inputs:
     - vec
 outputs:
@@ -51,6 +55,7 @@ dimensions:
 shader: "@out = @vec.x;"
 ---
 name: VY
+rates: [ frame, shape, pixel ]
 inputs:
     - vec
 outputs:
@@ -65,6 +70,7 @@ dimensions:
 shader: "@out = @vec.y;"
 ---
 name: VZ
+rates: [ frame, shape, pixel ]
 inputs:
     - vec
 outputs:
@@ -77,6 +83,7 @@ dimensions:
 shader: "@out = @vec.z;"
 ---
 name: VW
+rates: [ frame, shape, pixel ]
 inputs:
     - vec
 outputs:
@@ -87,6 +94,7 @@ dimensions:
 shader: "@out = @vec.w;"
 ---
 name: Splat2
+rates: [ frame, shape, pixel ]
 inputs:
     - x
 outputs:
@@ -97,6 +105,7 @@ dimensions:
 shader: "@out = vec2(@x, @x);"
 ---
 name: Splat3
+rates: [ frame, shape, pixel ]
 inputs:
     - x
 outputs:
@@ -107,6 +116,7 @@ dimensions:
 shader: "@out = vec3(@x, @x, @x);"
 ---
 name: Splat4
+rates: [ frame, shape, pixel ]
 inputs:
     - x
 outputs:


### PR DESCRIPTION
## Purpose and motivation

The (hopefully) final names for the thee rates VGens run at are `frame`, `shape`, and `pixel`. Adds support to the VGen and ScinthDef specifications for providing those rates, and documents supported rates for each of the exiting VGens.

## Implementation

Repurposes the `.fr` to mean frame rate and  adds `.sr` and `.pr` methods to support the new rate names. Adds support for parsing ScinthDef and VGen yaml with rate descriptions. Adds ScinthDef code to validate that rates only increase from input to output. Add some supported rate checking on VGen validation.

## Types of changes

* Behaviour change
* Enhancement

## Status

- [x] This PR is ready for review
- [x] Unit tests added
- [x] Unit tests are passing
