### PR TITLE
Adds support for frame-rate VGens

### DIFF
--- a/classes/ScinthDef.sc
+++ b/classes/ScinthDef.sc
@@ -79,8 +79,9 @@ ScinthDef {
 	prCheckRates { |vgen, rate|
 		switch (rate,
 			\frame, {
-				if (vgen.rate !== \frame, {
-					Error.new("Frame rate VGen can only accept other frame rate VGens as input").throw;
+				if (vgen.rate !== \frame and: { vgen.rate !== \param }, {
+					Error.new("Frame rate VGen can only accept other frame rate VGens as input, got a rate of %"
+						.format(vgen.rate)).throw;
 				});
 			},
 			\shape, {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -561,7 +561,7 @@ add_custom_target(sclang_language_config
 )
 
 # Reference source and test images. We always use a specific git hash, to control which images we compare against.
-set(SCIN_TEST_IMAGE_HASH "a69177003cd3b3c569e04c08cc516d04dc2db6cb")
+set(SCIN_TEST_IMAGE_HASH "0f678b542d98b2b270e63034bfabbd87e103bbd9")
 ExternalProject_Add(reference_images
     PREFIX ref
     STEP_TARGETS update

--- a/src/base/AbstractScinthDef.cpp
+++ b/src/base/AbstractScinthDef.cpp
@@ -674,7 +674,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
                 if (m_uniformManifest.intrinsicForElement(i) == kNotFound) {
                     m_computeShader += fmt::format("\n    // -- export compute VGen output to uniform buffer"
                                                    "\n    {}_ubo.{} = {}_{};\n",
-                                                   m_prefix, fest.nameForElement(i),
+                                                   m_prefix, m_uniformManifest.nameForElement(i),
                                                    m_prefix, m_uniformManifest.nameForElement(i));
                 }
             }

--- a/src/base/AbstractScinthDef.cpp
+++ b/src/base/AbstractScinthDef.cpp
@@ -609,14 +609,14 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
 
         vertexHeader += fmt::format("\n"
                                     "// --- buffer for compute shader outputs\n"
-                                    "layout(binding = {}) buffer ComputeBuffer {{\n"
+                                    "layout(binding = {}) readonly buffer computeBuffer {{\n"
                                     "{}"
                                     "}} {}_compute_buffer;\n",
                                     binding, bufferBody, m_prefix);
 
         fragmentHeader += fmt::format("\n"
                                       "// --- buffer for compute shader outputs\n"
-                                      "layout(binding = {}) buffer ComputeBuffer {{\n"
+                                      "layout(binding = {}) readonly buffer computeBuffer {{\n"
                                       "{}"
                                       "}} {}_compute_buffer;\n",
                                       binding, bufferBody, m_prefix);
@@ -746,7 +746,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
 
         computeHeader += fmt::format("\n"
                                      "// --- buffer for compute shader outputs\n"
-                                     "layout(binding = {}) buffer ComputeBuffer {{\n"
+                                     "layout(binding = {}) buffer computeBuffer {{\n"
                                      "{}"
                                      "}} {}_compute_buffer;\n",
                                      binding, bufferBody, m_prefix);

--- a/src/base/AbstractScinthDef.cpp
+++ b/src/base/AbstractScinthDef.cpp
@@ -405,7 +405,7 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
                 case AbstractVGen::Rates::kPixel:
                 case AbstractVGen::Rates::kShape:
                     spdlog::error("Input from non frame-rate VGens not supported in frame-rate VGens at index {}",
-                            index);
+                                  index);
                     return false;
                     break;
 
@@ -429,7 +429,6 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
         std::unordered_map<Intrinsic, std::string> intrinsics;
         for (auto intrinsic : m_instances[index].abstractVGen()->intrinsics()) {
             switch (intrinsic) {
-
             case kNotFound:
                 spdlog::error("ScinthDef {} has unknown intrinsic.", m_name);
                 return false;
@@ -477,8 +476,8 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
 
         m_computeShader += fmt::format("\n    // --- {}\n", m_instances[index].abstractVGen()->name());
         m_computeShader += fmt::format("    {}\n",
-                                        m_instances[index].abstractVGen()->parameterize(
-                                            inputs, intrinsics, outputs, outputDimensions, alreadyDefined));
+                                       m_instances[index].abstractVGen()->parameterize(
+                                           inputs, intrinsics, outputs, outputDimensions, alreadyDefined));
     }
 
     return true;
@@ -605,7 +604,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
         std::string bufferBody;
         for (auto i = 0; i < m_computeManifest.numberOfElements(); ++i) {
             bufferBody += fmt::format("    {} {};\n", m_computeManifest.typeNameForElement(i),
-                    m_computeManifest.nameForElement(i));
+                                      m_computeManifest.nameForElement(i));
         }
 
         vertexHeader += fmt::format("\n"
@@ -691,7 +690,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
             std::string uboBody;
             for (auto i = 0; i < m_uniformManifest.numberOfElements(); ++i) {
                 uboBody += fmt::format("    {} {};\n", m_uniformManifest.typeNameForElement(i),
-                                        m_uniformManifest.nameForElement(i));
+                                       m_uniformManifest.nameForElement(i));
 
                 // Assumption here, similar to that in the vertex shader, that a non-intrinsic in the uniform represents
                 // an output from a frame-rate VGen that needs to be copied into the uniform buffer.
@@ -699,11 +698,11 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
                 }
             }
             computeHeader += fmt::format("\n"
-                                        "// -- compute shader uniform buffer\n"
-                                        "layout(binding = {}) uniform UBO {{\n"
-                                        "{}"
-                                        "}} {}_ubo;\n",
-                                        binding, uboBody, m_prefix);
+                                         "// -- compute shader uniform buffer\n"
+                                         "layout(binding = {}) uniform UBO {{\n"
+                                         "{}"
+                                         "}} {}_ubo;\n",
+                                         binding, uboBody, m_prefix);
 
 
             ++binding;
@@ -713,13 +712,13 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
         if (m_computeFixedImages.size()) {
             std::string samplerBody;
             for (auto pair : m_computeFixedImages) {
-                    samplerBody += fmt::format("layout(binding = {}) uniform sampler2D {}_sampler_{:08x}_fixed_{};\n",
-                                               binding, m_prefix, pair.first, pair.second);
-                    ++binding;
+                samplerBody += fmt::format("layout(binding = {}) uniform sampler2D {}_sampler_{:08x}_fixed_{};\n",
+                                           binding, m_prefix, pair.first, pair.second);
+                ++binding;
             }
             computeHeader += "\n"
                              "// -- fixed image sampler inputs\n"
-                             + samplerBody;
+                + samplerBody;
         }
 
         if (m_computeParameterizedImages.size()) {
@@ -731,18 +730,18 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
             }
             computeHeader += "\n"
                              "// --- parammeterized image sampler inputs\n"
-                             + samplerBody;
+                + samplerBody;
         }
 
         // Compute shader outputs in an output buffer, add copy instructions at the same time.
         std::string bufferBody;
         for (auto i = 0; i < m_computeManifest.numberOfElements(); ++i) {
             bufferBody += fmt::format("    {} {};\n", m_computeManifest.typeNameForElement(i),
-                    m_computeManifest.nameForElement(i));
+                                      m_computeManifest.nameForElement(i));
             m_computeShader += fmt::format("\n    // -- export compute VGen output to uniform buffer"
                                            "\n    {}_compute_buffer.{} = {}_{};\n",
-                                           m_prefix, m_computeManifest.nameForElement(i),
-                                           m_prefix, m_computeManifest.nameForElement(i));
+                                           m_prefix, m_computeManifest.nameForElement(i), m_prefix,
+                                           m_computeManifest.nameForElement(i));
         }
 
         computeHeader += fmt::format("\n"
@@ -760,17 +759,17 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
                 paramBody += fmt::format("  float {};\n", param.name());
             }
             computeHeader += fmt::format("\n"
-                                        "// --- compute shader parameter push constants\n"
-                                        "layout(push_constant) uniform parametersBlock {{\n"
-                                        "{}"
-                                        "}} {}_parameters;\n",
-                                        paramBody, m_prefix);
+                                         "// --- compute shader parameter push constants\n"
+                                         "layout(push_constant) uniform parametersBlock {{\n"
+                                         "{}"
+                                         "}} {}_parameters;\n",
+                                         paramBody, m_prefix);
         }
 
         m_computeShader = computeHeader
-        + "\n"
-          "void main() {"
-        + m_computeShader + "}\n";
+            + "\n"
+              "void main() {"
+            + m_computeShader + "}\n";
 
         spdlog::info("{} compute shader:\n{}", m_name, m_computeShader);
     }

--- a/src/base/AbstractScinthDef.hpp
+++ b/src/base/AbstractScinthDef.hpp
@@ -96,6 +96,7 @@ public:
     const Manifest& fragmentManifest() const { return m_fragmentManifest; }
     const Manifest& vertexManifest() const { return m_vertexManifest; }
     const Manifest& uniformManifest() const { return m_uniformManifest; }
+    const Manifest& computeManifest() const { return m_computeManifest; }
 
 private:
     /*! Recursively traverses the VGens list from output back to inputs, grouping them into compute, vertex, and
@@ -144,6 +145,9 @@ private:
 
     // Intrinsic and Shape inputs to the vertex shader.
     Manifest m_vertexManifest;
+
+    // Outputs from compute shader for reading in draw stages.
+    Manifest m_computeManifest;
 
     std::string m_fragmentShader;
     std::string m_vertexShader;

--- a/src/base/AbstractScinthDef.hpp
+++ b/src/base/AbstractScinthDef.hpp
@@ -28,14 +28,13 @@ class VGen;
  * produces as output:
  *
  * a) An optional compute shader, if there are any frame-rate VGens in the graph.
- * b) An input uniform buffer manifest for the compute shader if it exists, the compute uniform manifest
- * c) A uniform buffer manifest shared by the vertex and fragment programs, called the draw uniform manifest.
- * d) A vertex shader input manifest
- * e) A vertex shader containing both any shape-rate VGens as well as necessary pass-through data to the fragment shader
- * f) A vertex shader output manifest, one of the sources of input to the fragment shader, called the fragment manifest
- * g) Lists of unified Samplers both constant and parameterized for both compute and draw stages
- * h) Lists of parameters provided as push constants for both compute and draw stages
- * i) A fragment shader with the pixel-rate VGens
+ * b) A unified uniform buffer manifest containing any intrinsic inputs for the ScinthDef as well as compute outputs
+ * c) A vertex shader input manifest
+ * d) A vertex shader containing both any shape-rate VGens as well as necessary pass-through data to the fragment shader
+ * e) A vertex shader output manifest, one of the sources of input to the fragment shader, called the fragment manifest
+ * f) Lists of unified Samplers both constant and parameterized for both compute and draw stages
+ * g) Lists of parameters provided as push constants for both compute and draw stages
+ * h) A fragment shader with the pixel-rate VGens
  *
  * Overall approach is to take a first pass through the graph from output back to inputs, validating the rate flow and
  * bucketing the VGens into one of compute, vertex, or fragment shader groups. Then we take a forward pass through each
@@ -95,7 +94,7 @@ public:
     const std::string& fragmentShader() const { return m_fragmentShader; }
     const Manifest& fragmentManifest() const { return m_fragmentManifest; }
     const Manifest& vertexManifest() const { return m_vertexManifest; }
-    const Manifest& drawUniformManifest() const { return m_drawUniformManifest; }
+    const Manifest& uniformManifest() const { return m_uniformManifest; }
 
 private:
     /*! Recursively traverses the VGens list from output back to inputs, grouping them into compute, vertex, and
@@ -139,8 +138,8 @@ private:
     // Outputs from the vertex shader that are supplied as inputs to the fragment shader.
     Manifest m_fragmentManifest;
 
-    // Outputs from compute shader and any intrinsics are supplied as a uniform to both vertex and fragment shaders.
-    Manifest m_drawUniformManifest;
+    // Inputs to, and outputs from compute shader, and any intrinsics are supplied as a uniform to all shaders.
+    Manifest m_uniformManifest;
 
     // Intrinsic and Shape inputs to the vertex shader.
     Manifest m_vertexManifest;
@@ -149,14 +148,12 @@ private:
     std::string m_vertexShader;
     std::string m_computeShader;
 
-    Manifest m_computeUniformManifest;
     bool m_hasComputeStage;
 
     std::unordered_map<std::string, int> m_parameterIndices;
 };
 
 } // namespace base
-
 } // namespace scin
 
 #endif // SRC_CORE_ABSTRACT_SCINTHDEF_HPP_

--- a/src/base/AbstractScinthDef.hpp
+++ b/src/base/AbstractScinthDef.hpp
@@ -90,6 +90,7 @@ public:
     bool hasComputeStage() const { return m_hasComputeStage; }
 
     const std::string& prefix() const { return m_prefix; }
+    const std::string& computeShader() const { return m_computeShader; }
     const std::string& vertexShader() const { return m_vertexShader; }
     const std::string& fragmentShader() const { return m_fragmentShader; }
     const Manifest& fragmentManifest() const { return m_fragmentManifest; }

--- a/src/base/AbstractScinthDef_unittests.cpp
+++ b/src/base/AbstractScinthDef_unittests.cpp
@@ -191,7 +191,7 @@ TEST_F(AbstractScinthDefTest, BuildWithSinglePixelRateVGen) {
 
     // Fragment and uniform manifests should be empty.
     EXPECT_EQ(0, def->fragmentManifest().numberOfElements());
-    EXPECT_EQ(0, def->drawUniformManifest().numberOfElements());
+    EXPECT_EQ(0, def->uniformManifest().numberOfElements());
     // Vertex manifest should contain a single element, the position.
     ASSERT_EQ(1, def->vertexManifest().numberOfElements());
     EXPECT_EQ(Intrinsic::kPosition, def->vertexManifest().intrinsicForElement(0));
@@ -242,7 +242,7 @@ TEST_F(AbstractScinthDefTest, BuildWithNormPosPixelRate) {
     ASSERT_EQ(1, def->fragmentManifest().numberOfElements());
     EXPECT_EQ(Intrinsic::kNormPos, def->fragmentManifest().intrinsicForElement(0));
 
-    EXPECT_EQ(0, def->drawUniformManifest().numberOfElements());
+    EXPECT_EQ(0, def->uniformManifest().numberOfElements());
 
     // Vertex manifest should contain the position and the NormPos.
     std::unordered_set<Intrinsic> vertexIntrinsics { Intrinsic::kPosition, Intrinsic::kNormPos };
@@ -298,7 +298,7 @@ TEST_F(AbstractScinthDefTest, BuildWithTexPosPixelRate) {
     ASSERT_EQ(1, def->fragmentManifest().numberOfElements());
     EXPECT_EQ(Intrinsic::kTexPos, def->fragmentManifest().intrinsicForElement(0));
 
-    EXPECT_EQ(0, def->drawUniformManifest().numberOfElements());
+    EXPECT_EQ(0, def->uniformManifest().numberOfElements());
 
     // Vertex manifest should contain the position and the NormPos.
     std::unordered_set<Intrinsic> vertexIntrinsics { Intrinsic::kPosition, Intrinsic::kTexPos };
@@ -345,8 +345,8 @@ TEST_F(AbstractScinthDefTest, BuildWithTimePixelRate) {
     EXPECT_EQ(0, def->fragmentManifest().numberOfElements());
 
     // One element in the draw uniform manifest, the time intrinsic.
-    ASSERT_EQ(1, def->drawUniformManifest().numberOfElements());
-    EXPECT_EQ(Intrinsic::kTime, def->drawUniformManifest().intrinsicForElement(0));
+    ASSERT_EQ(1, def->uniformManifest().numberOfElements());
+    EXPECT_EQ(Intrinsic::kTime, def->uniformManifest().intrinsicForElement(0));
 
     // Vertex manifest should contain only the position.
     ASSERT_EQ(1, def->vertexManifest().numberOfElements());
@@ -390,7 +390,7 @@ TEST_F(AbstractScinthDefTest, BuildPixelRateParams) {
 
     // Fragment and uniform manifests should be empty.
     EXPECT_EQ(0, def->fragmentManifest().numberOfElements());
-    EXPECT_EQ(0, def->drawUniformManifest().numberOfElements());
+    EXPECT_EQ(0, def->uniformManifest().numberOfElements());
     // Vertex manifest should contain a single element, the position.
     ASSERT_EQ(1, def->vertexManifest().numberOfElements());
     EXPECT_EQ(Intrinsic::kPosition, def->vertexManifest().intrinsicForElement(0));

--- a/src/base/Manifest.cpp
+++ b/src/base/Manifest.cpp
@@ -11,7 +11,6 @@ Manifest::~Manifest() {}
 
 bool Manifest::addElement(const std::string& name, ElementType type, Intrinsic intrinsic) {
     if (m_types.find(name) != m_types.end()) {
-        spdlog::error("duplicate addition to Manifest of {}", name);
         return false;
     }
 

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -276,7 +276,10 @@ void Compositor::destroy() {
         m_scinths.clear();
         m_audioStagers.clear();
     }
-    // TODO: as a last resort, could call destroy on each of these
+    m_computePrimary.reset();
+    m_computeSecondary.clear();
+    m_computeCommands.clear();
+
     m_drawPrimary.reset();
     m_drawSecondary.clear();
     m_drawCommands.clear();

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -34,7 +34,8 @@ Compositor::Compositor(std::shared_ptr<vk::Device> device, std::shared_ptr<Canva
     m_imageMap(new ImageMap()),
     m_commandBufferDirty(true),
     m_nodeSerial(-2) {
-    m_frameCommands.resize(m_canvas->numberOfImages());
+    m_computeCommands.resize(m_canvas->numberOfImages());
+    m_drawCommands.resize(m_canvas->numberOfImages());
 }
 
 Compositor::~Compositor() {}
@@ -58,7 +59,6 @@ bool Compositor::create() {
         spdlog::error("Compositor failed to create stage manager.");
         return false;
     }
-
 
     // Create the empty image and stage.
     std::shared_ptr<vk::HostBuffer> emptyImageBuffer(new vk::HostBuffer(m_device, vk::Buffer::Kind::kStaging, 4));
@@ -91,8 +91,8 @@ bool Compositor::create() {
 }
 
 bool Compositor::buildScinthDef(std::shared_ptr<const base::AbstractScinthDef> abstractScinthDef) {
-    std::shared_ptr<ScinthDef> scinthDef(
-        new ScinthDef(m_device, m_canvas, m_computeCommandPool, m_drawCommandPool, m_samplerFactory, abstractScinthDef));
+    std::shared_ptr<ScinthDef> scinthDef(new ScinthDef(m_device, m_canvas, m_computeCommandPool, m_drawCommandPool,
+                                                       m_samplerFactory, abstractScinthDef));
     if (!scinthDef->build(m_shaderCompiler.get())) {
         return false;
     }
@@ -229,7 +229,8 @@ void Compositor::setNodeParameters(int nodeID, const std::vector<std::pair<std::
 }
 
 std::shared_ptr<vk::CommandBuffer> Compositor::prepareFrame(uint32_t imageIndex, double frameTime) {
-    m_secondaryCommands.clear();
+    m_computeSecondary.clear();
+    m_drawSecondary.clear();
 
     {
         std::lock_guard<std::mutex> lock(m_scinthMutex);
@@ -240,19 +241,25 @@ std::shared_ptr<vk::CommandBuffer> Compositor::prepareFrame(uint32_t imageIndex,
         for (auto scinth : m_scinths) {
             if (scinth->running()) {
                 scinth->prepareFrame(imageIndex, frameTime);
-                std::shared_ptr<vk::CommandBuffer> commands = scinth->drawCommands();
-                commands->associateScinth(scinth);
-                m_secondaryCommands.emplace_back(commands);
+                std::shared_ptr<vk::CommandBuffer> computeCommands = scinth->computeCommands();
+                if (computeCommands) {
+                    computeCommands->associateScinth(scinth);
+                    m_computeSecondary.emplace_back(computeCommands);
+                }
+                std::shared_ptr<vk::CommandBuffer> drawCommands = scinth->drawCommands();
+                drawCommands->associateScinth(scinth);
+                m_drawSecondary.emplace_back(drawCommands);
             }
         }
     }
 
-    m_frameCommands[imageIndex] = m_secondaryCommands;
+    m_computeCommands[imageIndex] = m_computeSecondary;
+    m_drawCommands[imageIndex] = m_drawSecondary;
 
     if (m_commandBufferDirty) {
         rebuildCommandBuffer();
     }
-    return m_primaryCommands;
+    return m_drawPrimary;
 }
 
 void Compositor::releaseCompiler() { m_shaderCompiler->releaseCompiler(); }
@@ -269,9 +276,9 @@ void Compositor::destroy() {
         m_audioStagers.clear();
     }
     // TODO: as a last resort, could call destroy on each of these
-    m_primaryCommands.reset();
-    m_secondaryCommands.clear();
-    m_frameCommands.clear();
+    m_drawPrimary.reset();
+    m_drawSecondary.clear();
+    m_drawCommands.clear();
 
     // We leave the command pools undestroyed as there may be outstanding commandbuffers pipelined. The shared_ptr
     // system should collect them before all is done. But we must remove our references to them or we keep them alive
@@ -349,22 +356,25 @@ bool Compositor::addAudioIngress(std::shared_ptr<audio::Ingress> ingress, int im
     return true;
 }
 
-// Needs to be called only from the same thread that calls prepareFrame. Assumes that m_secondaryCommands is up-to-date.
+// Needs to be called only from the same thread that calls prepareFrame. Assumes that m_drawSecondary is up-to-date.
 bool Compositor::rebuildCommandBuffer() {
-    m_primaryCommands.reset(new vk::CommandBuffer(m_device, m_drawCommandPool));
-    if (!m_primaryCommands->create(m_canvas->numberOfImages(), true)) {
+    m_computePrimary.reset(new vk::CommandBuffer(m_device, m_computeCommandPool));
+
+
+    m_drawPrimary.reset(new vk::CommandBuffer(m_device, m_drawCommandPool));
+    if (!m_drawPrimary->create(m_canvas->numberOfImages(), true)) {
         spdlog::critical("failed creating primary command buffers for Compositor.");
         return false;
     }
 
     // Ensure the secondary command buffers get retained as long as this buffer is retained.
-    m_primaryCommands->associateSecondaryCommands(m_secondaryCommands);
+    m_drawPrimary->associateSecondaryCommands(m_drawSecondary);
 
     VkClearColorValue clearColor = { { m_clearColor.x, m_clearColor.y, m_clearColor.z, 1.0f } };
     VkClearValue clearValue = {};
     clearValue.color = clearColor;
 
-    spdlog::debug("rebuilding Compositor command buffer with {} secondary command buffers", m_secondaryCommands.size());
+    spdlog::debug("rebuilding Compositor command buffer with {} secondary command buffers", m_drawSecondary.size());
 
     for (auto i = 0; i < m_canvas->numberOfImages(); ++i) {
         VkCommandBufferBeginInfo beginInfo = {};
@@ -372,7 +382,7 @@ bool Compositor::rebuildCommandBuffer() {
         beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
         beginInfo.pInheritanceInfo = nullptr;
 
-        if (vkBeginCommandBuffer(m_primaryCommands->buffer(i), &beginInfo) != VK_SUCCESS) {
+        if (vkBeginCommandBuffer(m_drawPrimary->buffer(i), &beginInfo) != VK_SUCCESS) {
             spdlog::error("Compositor failed beginning primary command buffer.");
             return false;
         }
@@ -386,21 +396,21 @@ bool Compositor::rebuildCommandBuffer() {
         renderPassInfo.clearValueCount = 1;
         renderPassInfo.pClearValues = &clearValue;
 
-        if (m_secondaryCommands.size()) {
-            vkCmdBeginRenderPass(m_primaryCommands->buffer(i), &renderPassInfo,
+        if (m_drawSecondary.size()) {
+            vkCmdBeginRenderPass(m_drawPrimary->buffer(i), &renderPassInfo,
                                  VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
             std::vector<VkCommandBuffer> commandBuffers;
-            for (auto command : m_secondaryCommands) {
+            for (auto command : m_drawSecondary) {
                 commandBuffers.emplace_back(command->buffer(i));
             }
-            vkCmdExecuteCommands(m_primaryCommands->buffer(i), commandBuffers.size(), commandBuffers.data());
+            vkCmdExecuteCommands(m_drawPrimary->buffer(i), commandBuffers.size(), commandBuffers.data());
         } else {
-            vkCmdBeginRenderPass(m_primaryCommands->buffer(i), &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+            vkCmdBeginRenderPass(m_drawPrimary->buffer(i), &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
         }
 
-        vkCmdEndRenderPass(m_primaryCommands->buffer(i));
-        if (vkEndCommandBuffer(m_primaryCommands->buffer(i)) != VK_SUCCESS) {
+        vkCmdEndRenderPass(m_drawPrimary->buffer(i));
+        if (vkEndCommandBuffer(m_drawPrimary->buffer(i)) != VK_SUCCESS) {
             spdlog::error("Compositor failed ending primary command buffer.");
             return false;
         }

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -368,7 +368,7 @@ bool Compositor::rebuildCommandBuffer() {
 
         m_computePrimary->associateSecondaryCommands(m_computeSecondary);
         spdlog::debug("rebuilding Compositor compute command buffer with {} secondary command buffers",
-                m_computeSecondary.size());
+                      m_computeSecondary.size());
 
         for (auto i = 0; i < m_canvas->numberOfImages(); ++i) {
             VkCommandBufferBeginInfo beginInfo = {};

--- a/src/comp/Compositor.hpp
+++ b/src/comp/Compositor.hpp
@@ -199,11 +199,16 @@ private:
     AudioStagerList m_audioStagers;
 
     // Following should only be accessed from the same thread that calls prepareFrame.
-    std::shared_ptr<vk::CommandBuffer> m_primaryCommands;
+    std::shared_ptr<vk::CommandBuffer> m_drawPrimary;
     // We keep the subcommand buffers referenced each frame, and make a copy of them at each image index, so that they
     // are always valid until we are rendering a new frame over the old commands.
-    Commands m_secondaryCommands;
-    std::vector<Commands> m_frameCommands;
+    Commands m_drawSecondary;
+
+    std::shared_ptr<vk::CommandBuffer> m_computePrimary;
+    Commands m_computeSecondary;
+
+    std::vector<Commands> m_computeCommands;
+    std::vector<Commands> m_drawCommands;
 };
 
 } // namespace comp

--- a/src/comp/Compositor.hpp
+++ b/src/comp/Compositor.hpp
@@ -102,13 +102,17 @@ public:
     void setNodeParameters(int nodeID, const std::vector<std::pair<std::string, float>>& namedValues,
                            const std::vector<std::pair<int, float>> indexedValues);
 
-    /*! Prepare and return a CommandBuffers that when executed in order will render the current frame.
+    /*! Prepare the CommandBuffers that when executed in order will render the current frame. Updates the values
+     * returned by computeCommands() and drawCommands().
      *
      * \param imageIndex The index of the imageView in the Canvas we will be rendering in to.
      * \param frameTime The point in time at which to build this frame for.
-     * \return A CommandBuffer object to be scheduled for graphics queue submission.
+     * \return A boolean indicating success in frame preparation.
      */
-    std::shared_ptr<vk::CommandBuffer> prepareFrame(uint32_t imageIndex, double frameTime);
+    bool prepareFrame(uint32_t imageIndex, double frameTime);
+
+    std::shared_ptr<vk::CommandBuffer> computeCommands() { return m_computePrimary; }
+    std::shared_ptr<vk::CommandBuffer> drawCommands() { return m_drawPrimary; }
 
     /*! Unload the shader compiler, releasing the resources associated with it.
      *

--- a/src/comp/Compositor.hpp
+++ b/src/comp/Compositor.hpp
@@ -178,7 +178,8 @@ private:
     glm::vec3 m_clearColor;
 
     std::unique_ptr<ShaderCompiler> m_shaderCompiler;
-    std::shared_ptr<vk::CommandPool> m_commandPool;
+    std::shared_ptr<vk::CommandPool> m_computeCommandPool;
+    std::shared_ptr<vk::CommandPool> m_drawCommandPool;
     std::shared_ptr<StageManager> m_stageManager;
     std::shared_ptr<SamplerFactory> m_samplerFactory;
     std::shared_ptr<ImageMap> m_imageMap;

--- a/src/comp/Offscreen.cpp
+++ b/src/comp/Offscreen.cpp
@@ -344,7 +344,7 @@ void Offscreen::threadMain(std::shared_ptr<Compositor> compositor) {
             // TODO: might get some performance improvement by submitting transfers to the transfer queue as part of a
             // separate submission. Could also work for the StageManager. Then we would be waiting on the prior
             // transfers having completed, if any.
-            if (frameNumber > m_numberOfImages) {
+            if (frameNumber >= m_numberOfImages) {
                 // We can wait on the semaphore that we also signal as long as it has been signaled by a prior render
                 // on this image.
                 drawSubmitInfo.waitSemaphoreCount = 1;

--- a/src/comp/Offscreen.cpp
+++ b/src/comp/Offscreen.cpp
@@ -301,7 +301,12 @@ void Offscreen::threadMain(std::shared_ptr<Compositor> compositor) {
         processPendingEncodes(frameIndex);
 
         // OK, we now consider the contents of the framebuffer (and any blit targets) as subject to GPU mutation.
-        m_commandBuffers[frameIndex] = compositor->prepareFrame(frameIndex, time);
+        if (!compositor->prepareFrame(frameIndex, time)) {
+            spdlog::critical("Failed to prepare frame, terminating.");
+            break;
+        }
+
+        m_commandBuffers[frameIndex] = compositor->drawCommands();
 
         std::vector<VkCommandBuffer> commandBuffers;
         commandBuffers.push_back(m_commandBuffers[frameIndex]->buffer(frameIndex));

--- a/src/comp/Offscreen.hpp
+++ b/src/comp/Offscreen.hpp
@@ -139,7 +139,8 @@ private:
 
     // threadMain-only access
     std::thread m_renderThread;
-    std::vector<std::shared_ptr<vk::CommandBuffer>> m_commandBuffers;
+    std::vector<std::shared_ptr<vk::CommandBuffer>> m_computeCommands;
+    std::vector<std::shared_ptr<vk::CommandBuffer>> m_drawCommands;
     std::vector<std::vector<scin::av::Encoder::SendBuffer>> m_pendingEncodes;
     std::vector<std::shared_ptr<vk::HostImage>> m_readbackImages;
     bool m_readbackSupportsBlit;

--- a/src/comp/Pipeline.cpp
+++ b/src/comp/Pipeline.cpp
@@ -233,6 +233,8 @@ void Pipeline::destroy() {
 
 bool Pipeline::createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescriptorSetLayout descriptorSetLayout,
         size_t pushConstantBlockSize) {
+    m_computeShader = computeShader;
+
     // Pipeline Layout
     VkPipelineLayoutCreateInfo pipelineLayoutInfo = {};
     pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;

--- a/src/comp/Pipeline.cpp
+++ b/src/comp/Pipeline.cpp
@@ -167,7 +167,7 @@ bool Pipeline::create(const base::Manifest& vertexManifest, const base::Shape* s
     }
     VkPushConstantRange pushConstantRange = {};
     if (pushConstantBlockSize) {
-        pushConstantRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        pushConstantRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_VERTEX_BIT;
         pushConstantRange.offset = 0;
         pushConstantRange.size = pushConstantBlockSize;
         pipelineLayoutInfo.pushConstantRangeCount = 1;
@@ -229,6 +229,51 @@ void Pipeline::destroy() {
         vkDestroyPipeline(m_device->get(), m_pipeline, nullptr);
         m_pipeline = VK_NULL_HANDLE;
     }
+}
+
+bool Pipeline::createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescriptorSetLayout descriptorSetLayout,
+        size_t pushConstantBlockSize) {
+    // Pipeline Layout
+    VkPipelineLayoutCreateInfo pipelineLayoutInfo = {};
+    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    VkDescriptorSetLayout setLayouts[] = { descriptorSetLayout };
+    if (descriptorSetLayout != VK_NULL_HANDLE) {
+        pipelineLayoutInfo.setLayoutCount = 1;
+        pipelineLayoutInfo.pSetLayouts = setLayouts;
+    } else {
+        pipelineLayoutInfo.setLayoutCount = 0;
+        pipelineLayoutInfo.pSetLayouts = nullptr;
+    }
+    VkPushConstantRange pushConstantRange = {};
+    if (pushConstantBlockSize) {
+        pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        pushConstantRange.offset = 0;
+        pushConstantRange.size = pushConstantBlockSize;
+        pipelineLayoutInfo.pushConstantRangeCount = 1;
+        pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
+    } else {
+        pipelineLayoutInfo.pushConstantRangeCount = 0;
+        pipelineLayoutInfo.pPushConstantRanges = nullptr;
+    }
+
+    if (vkCreatePipelineLayout(m_device->get(), &pipelineLayoutInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS) {
+        return false;
+    }
+
+    VkComputePipelineCreateInfo pipelineInfo = {};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pipelineInfo.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    pipelineInfo.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    pipelineInfo.stage.module = computeShader->get();
+    pipelineInfo.stage.pName = computeShader->entryPoint();
+    pipelineInfo.layout = m_pipelineLayout;
+    pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
+    pipelineInfo.basePipelineIndex = -1;
+
+    return (vkCreateComputePipelines(m_device->get(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &m_pipeline)
+            == VK_SUCCESS);
+
+    return true;
 }
 
 } // namespace vk

--- a/src/comp/Pipeline.cpp
+++ b/src/comp/Pipeline.cpp
@@ -232,7 +232,7 @@ void Pipeline::destroy() {
 }
 
 bool Pipeline::createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescriptorSetLayout descriptorSetLayout,
-        size_t pushConstantBlockSize) {
+                             size_t pushConstantBlockSize) {
     m_computeShader = computeShader;
 
     // Pipeline Layout

--- a/src/comp/Pipeline.hpp
+++ b/src/comp/Pipeline.hpp
@@ -32,8 +32,8 @@ public:
                 std::shared_ptr<vk::Shader> vertexShader, std::shared_ptr<vk::Shader> fragmentShader,
                 VkDescriptorSetLayout descriptorSetLayout, size_t pushConstantBlockSize,
                 const base::RenderOptions& renderOptions);
-    bool createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescriptorSetLayout descriptorSetLayout, size_t
-            pushConstantBlockSize);
+    bool createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescriptorSetLayout descriptorSetLayout,
+                       size_t pushConstantBlockSize);
     void destroy();
 
     VkPipeline get() { return m_pipeline; }

--- a/src/comp/Pipeline.hpp
+++ b/src/comp/Pipeline.hpp
@@ -32,6 +32,8 @@ public:
                 std::shared_ptr<vk::Shader> vertexShader, std::shared_ptr<vk::Shader> fragmentShader,
                 VkDescriptorSetLayout descriptorSetLayout, size_t pushConstantBlockSize,
                 const base::RenderOptions& renderOptions);
+    bool createCompute(std::shared_ptr<vk::Shader> computeshader, VkDescriptorSetLayout descriptorSetLayout, size_t
+            pushConstantBlockSize);
     void destroy();
 
     VkPipeline get() { return m_pipeline; }

--- a/src/comp/Pipeline.hpp
+++ b/src/comp/Pipeline.hpp
@@ -32,7 +32,7 @@ public:
                 std::shared_ptr<vk::Shader> vertexShader, std::shared_ptr<vk::Shader> fragmentShader,
                 VkDescriptorSetLayout descriptorSetLayout, size_t pushConstantBlockSize,
                 const base::RenderOptions& renderOptions);
-    bool createCompute(std::shared_ptr<vk::Shader> computeshader, VkDescriptorSetLayout descriptorSetLayout, size_t
+    bool createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescriptorSetLayout descriptorSetLayout, size_t
             pushConstantBlockSize);
     void destroy();
 
@@ -47,6 +47,7 @@ private:
 
     std::shared_ptr<vk::Shader> m_vertexShader;
     std::shared_ptr<vk::Shader> m_fragmentShader;
+    std::shared_ptr<vk::Shader> m_computeShader;
 };
 
 } // namespace vk

--- a/src/comp/RenderSync.hpp
+++ b/src/comp/RenderSync.hpp
@@ -28,10 +28,10 @@ public:
      * simultaneously in-progress frames.
      *
      * \param inflightFrames How many sets of sync primitives to make. Should be > 0.
-     * \param makeSemaphores If the semaphores (mostly useful for Swapchains) should be made.
+     * \param makeSemaphores If the swapchain semaphore should be made.
      * \return true on success, false on failure.
      */
-    bool create(size_t inFlightFrames, bool makeSemaphores);
+    bool create(size_t inFlightFrames, bool makeSwapchainSemaphore);
 
     /*! Release synchronization primitives.
      */
@@ -39,11 +39,12 @@ public:
 
     void waitForFrame(size_t index);
 
-    // Requires that the semaphores were made.
+    // Requires that the swapchain (imageAvailable) semaphores were made.
     uint32_t acquireNextImage(size_t index, Swapchain* swapchain);
 
     void resetFrame(size_t index);
 
+    VkSemaphore computeFinished(size_t index) { return m_computeFinished[index]; }
     VkSemaphore imageAvailable(size_t index) { return m_imageAvailable[index]; }
     VkSemaphore renderFinished(size_t index) { return m_renderFinished[index]; }
     VkFence frameRendering(size_t index) { return m_frameRendering[index]; }
@@ -51,6 +52,7 @@ public:
 private:
     std::shared_ptr<vk::Device> m_device;
 
+    std::vector<VkSemaphore> m_computeFinished;
     std::vector<VkSemaphore> m_imageAvailable;
     std::vector<VkSemaphore> m_renderFinished;
     std::vector<VkFence> m_frameRendering;

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -478,8 +478,8 @@ bool Scinth::rebuildBuffers() {
 
         if (m_numberOfParameters) {
             vkCmdPushConstants(m_drawCommands->buffer(i), m_scinthDef->drawPipeline()->layout(),
-                               VK_SHADER_STAGE_FRAGMENT_BIT, 0, m_numberOfParameters * sizeof(float),
-                               m_parameterValues.get());
+                               VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
+                               m_numberOfParameters * sizeof(float), m_parameterValues.get());
         }
 
         vkCmdBindPipeline(m_drawCommands->buffer(i), VK_PIPELINE_BIND_POINT_GRAPHICS,

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -73,8 +73,8 @@ bool Scinth::prepareFrame(size_t imageIndex, double frameTime) {
     // Update the Uniform buffer at imageIndex, if needed.
     if (m_uniformBuffers.size()) {
         float* uniform = static_cast<float*>(m_uniformBuffers[imageIndex]->mappedAddress());
-        for (auto i = 0; i < m_scinthDef->abstract()->drawUniformManifest().numberOfElements(); ++i) {
-            switch (m_scinthDef->abstract()->drawUniformManifest().intrinsicForElement(i)) {
+        for (auto i = 0; i < m_scinthDef->abstract()->uniformManifest().numberOfElements(); ++i) {
+            switch (m_scinthDef->abstract()->uniformManifest().intrinsicForElement(i)) {
             case base::Intrinsic::kTime:
                 *uniform = static_cast<float>(frameTime - m_startTime);
                 break;
@@ -89,7 +89,7 @@ bool Scinth::prepareFrame(size_t imageIndex, double frameTime) {
                 return false;
             }
 
-            uniform += (m_scinthDef->abstract()->drawUniformManifest().strideForElement(i) / sizeof(float));
+            uniform += (m_scinthDef->abstract()->uniformManifest().strideForElement(i) / sizeof(float));
         }
     }
 
@@ -127,7 +127,7 @@ bool Scinth::allocateDescriptors() {
     auto numberOfImages = m_scinthDef->canvas()->numberOfImages();
     std::vector<VkDescriptorPoolSize> poolSizes;
 
-    auto uniformSize = m_scinthDef->abstract()->drawUniformManifest().sizeInBytes();
+    auto uniformSize = m_scinthDef->abstract()->uniformManifest().sizeInBytes();
     if (uniformSize) {
         VkDescriptorPoolSize uniformPoolSize = {};
         uniformPoolSize.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -297,7 +297,7 @@ bool Scinth::updateDescriptors() {
     }
 
     // Compute index where parameterized images binding starts.
-    int32_t bindingStart = m_scinthDef->abstract()->drawUniformManifest().sizeInBytes() ? 1 : 0;
+    int32_t bindingStart = m_scinthDef->abstract()->uniformManifest().sizeInBytes() ? 1 : 0;
     bindingStart += m_scinthDef->abstract()->drawFixedImages().size();
 
     for (auto i = 0; i < m_scinthDef->canvas()->numberOfImages(); ++i) {

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -60,6 +60,7 @@ bool Scinth::create() {
 void Scinth::destroy() {
     // Break circular references here so Scinth can be automatically reclaimed when referencing objects (namely the
     // command buffer) go out of scope and are themselves deleted.
+    m_computeCommands.reset();
     m_drawCommands.reset();
 }
 
@@ -386,6 +387,9 @@ bool Scinth::rebuildBuffers() {
             VkCommandBufferBeginInfo beginInfo = {};
             beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
+            VkCommandBufferInheritanceInfo inheritanceInfo = {};
+            inheritanceInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
+            beginInfo.pInheritanceInfo = &inheritanceInfo;
 
             if (vkBeginCommandBuffer(m_computeCommands->buffer(i), &beginInfo) != VK_SUCCESS) {
                 spdlog::error("failed beginning compute command buffer {} for Scinth {}", i, m_nodeID);

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -359,11 +359,11 @@ bool Scinth::rebuildBuffers() {
         }
 
         if (m_numberOfParameters) {
-            vkCmdPushConstants(m_commands->buffer(i), m_scinthDef->pipeline()->layout(), VK_SHADER_STAGE_FRAGMENT_BIT,
+            vkCmdPushConstants(m_commands->buffer(i), m_scinthDef->drawPipeline()->layout(), VK_SHADER_STAGE_FRAGMENT_BIT,
                                0, m_numberOfParameters * sizeof(float), m_parameterValues.get());
         }
 
-        vkCmdBindPipeline(m_commands->buffer(i), VK_PIPELINE_BIND_POINT_GRAPHICS, m_scinthDef->pipeline()->get());
+        vkCmdBindPipeline(m_commands->buffer(i), VK_PIPELINE_BIND_POINT_GRAPHICS, m_scinthDef->drawPipeline()->get());
         VkBuffer vertexBuffers[] = { m_scinthDef->vertexBuffer()->buffer() };
         VkDeviceSize offsets[] = { 0 };
         vkCmdBindVertexBuffers(m_commands->buffer(i), 0, 1, vertexBuffers, offsets);
@@ -371,7 +371,7 @@ bool Scinth::rebuildBuffers() {
 
         if (m_descriptorSets.size()) {
             vkCmdBindDescriptorSets(m_commands->buffer(i), VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                    m_scinthDef->pipeline()->layout(), 0, 1, &m_descriptorSets[i], 0, nullptr);
+                                    m_scinthDef->drawPipeline()->layout(), 0, 1, &m_descriptorSets[i], 0, nullptr);
         }
 
         vkCmdDrawIndexed(m_commands->buffer(i), m_scinthDef->abstract()->shape()->numberOfIndices(), 1, 0, 0, 0);

--- a/src/comp/Scinth.hpp
+++ b/src/comp/Scinth.hpp
@@ -13,6 +13,7 @@ namespace vk {
 class CommandBuffer;
 class CommandPool;
 class Device;
+class DeviceBuffer;
 class DeviceImage;
 class HostBuffer;
 }
@@ -70,7 +71,8 @@ public:
      */
     void setParameterByIndex(int index, float value);
 
-    std::shared_ptr<vk::CommandBuffer> frameCommands() { return m_commands; }
+    std::shared_ptr<vk::CommandBuffer> computeCommands() { return m_computeCommands; }
+    std::shared_ptr<vk::CommandBuffer> drawCommands() { return m_drawCommands; }
     int nodeID() const { return m_nodeID; }
     bool running() const { return m_running; }
 
@@ -93,9 +95,11 @@ private:
     std::vector<std::shared_ptr<vk::DeviceImage>> m_fixedImages;
     std::vector<std::shared_ptr<vk::DeviceImage>> m_parameterizedImages;
     std::vector<std::shared_ptr<vk::HostBuffer>> m_uniformBuffers;
+    std::vector<std::shared_ptr<vk::DeviceBuffer>> m_computeBuffers;
     // The parameter index and the currently bound image Ids for parameterized images.
     std::vector<std::pair<int, int>> m_parameterizedImageIDs;
-    std::shared_ptr<vk::CommandBuffer> m_commands;
+    std::shared_ptr<vk::CommandBuffer> m_computeCommands;
+    std::shared_ptr<vk::CommandBuffer> m_drawCommands;
     bool m_running;
     std::unique_ptr<float[]> m_parameterValues;
     size_t m_numberOfParameters;

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -83,21 +83,22 @@ bool ScinthDef::build(ShaderCompiler* compiler) {
 
     m_drawPipeline.reset(new Pipeline(m_device));
     if (!m_drawPipeline->create(m_abstract->vertexManifest(), m_abstract->shape(), m_canvas.get(), m_vertexShader,
-                            m_fragmentShader, m_descriptorSetLayout, m_abstract->parameters().size() * sizeof(float),
-                            m_abstract->renderOptions())) {
+                                m_fragmentShader, m_descriptorSetLayout,
+                                m_abstract->parameters().size() * sizeof(float), m_abstract->renderOptions())) {
         spdlog::error("Error creating draw pipeline for ScinthDef {}", m_abstract->name());
         return false;
     }
 
     if (m_abstract->hasComputeStage()) {
         m_computeShader = compiler->compile(m_device, m_abstract->computeShader(),
-                m_abstract->prefix() + "_computeShader", "main", vk::Shader::kCompute);
+                                            m_abstract->prefix() + "_computeShader", "main", vk::Shader::kCompute);
         if (!m_computeShader) {
             spdlog::error("error compiling compute shader for ScinthDef {}.", m_abstract->name());
             return false;
         }
         m_computePipeline.reset(new Pipeline(m_device));
-        if (!m_computePipeline->createCompute(m_computeShader, m_descriptorSetLayout, m_abstract->parameters().size())) {
+        if (!m_computePipeline->createCompute(m_computeShader, m_descriptorSetLayout,
+                                              m_abstract->parameters().size())) {
             spdlog::error("Error creating compute pipeline for ScinthDef {}", m_abstract->name());
             return false;
         }
@@ -145,7 +146,8 @@ bool ScinthDef::buildDescriptorLayout() {
         uniformBinding.binding = bindings.size();
         uniformBinding.descriptorCount = 1;
         uniformBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        uniformBinding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        uniformBinding.stageFlags =
+            VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
         bindings.emplace_back(uniformBinding);
     }
 
@@ -155,7 +157,8 @@ bool ScinthDef::buildDescriptorLayout() {
         imageBinding.binding = bindings.size();
         imageBinding.descriptorCount = 1;
         imageBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        imageBinding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        imageBinding.stageFlags =
+            VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
         bindings.emplace_back(imageBinding);
     }
 
@@ -164,7 +167,8 @@ bool ScinthDef::buildDescriptorLayout() {
         bufferBinding.binding = bindings.size();
         bufferBinding.descriptorCount = 1;
         bufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        bufferBinding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        bufferBinding.stageFlags =
+            VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
         bindings.emplace_back(bufferBinding);
     }
 

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -47,6 +47,15 @@ ScinthDef::~ScinthDef() {
 }
 
 bool ScinthDef::build(ShaderCompiler* compiler) {
+    if (m_abstract->hasComputeStage()) {
+        m_computeShader = compiler->compile(m_device, m_abstract->computeShader(),
+                m_abstract->prefix() + "_computeShader", "main", vk::Shader::kCompute);
+        if (!m_computeShader) {
+            spdlog::error("error compiling compute shader for ScinthDef {}.", m_abstract->name());
+            return false;
+        }
+    }
+
     // Build the vertex data. Because Intrinsics can add data payloads to the vertex data, each ScinthDef shares a
     // vertex buffer and index buffer across all Scinth instances, allowing for the potential unique combination
     // between Shape data and payloads.

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -98,7 +98,7 @@ bool ScinthDef::build(ShaderCompiler* compiler) {
         }
         m_computePipeline.reset(new Pipeline(m_device));
         if (!m_computePipeline->createCompute(m_computeShader, m_descriptorSetLayout,
-                                              m_abstract->parameters().size())) {
+                                              m_abstract->parameters().size() * sizeof(float))) {
             spdlog::error("Error creating compute pipeline for ScinthDef {}", m_abstract->name());
             return false;
         }

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -88,8 +88,8 @@ bool ScinthDef::build(ShaderCompiler* compiler) {
         return false;
     }
 
-    m_pipeline.reset(new Pipeline(m_device));
-    if (!m_pipeline->create(m_abstract->vertexManifest(), m_abstract->shape(), m_canvas.get(), m_vertexShader,
+    m_drawPipeline.reset(new Pipeline(m_device));
+    if (!m_drawPipeline->create(m_abstract->vertexManifest(), m_abstract->shape(), m_canvas.get(), m_vertexShader,
                             m_fragmentShader, m_descriptorSetLayout, m_abstract->parameters().size() * sizeof(float),
                             m_abstract->renderOptions())) {
         spdlog::error("error creating pipeline for ScinthDef {}", m_abstract->name());

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -124,7 +124,7 @@ bool ScinthDef::buildVertexData() {
 
 bool ScinthDef::buildDescriptorLayout() {
     std::vector<VkDescriptorSetLayoutBinding> bindings;
-    if (m_abstract->drawUniformManifest().sizeInBytes()) {
+    if (m_abstract->uniformManifest().sizeInBytes()) {
         VkDescriptorSetLayoutBinding uniformBinding = {};
         uniformBinding.binding = bindings.size();
         uniformBinding.descriptorCount = 1;

--- a/src/comp/ScinthDef.hpp
+++ b/src/comp/ScinthDef.hpp
@@ -33,8 +33,8 @@ class ShaderCompiler;
 class ScinthDef {
 public:
     ScinthDef(std::shared_ptr<vk::Device> device, std::shared_ptr<Canvas> canvas,
-              std::shared_ptr<vk::CommandPool> computeCommandPool,
-              std::shared_ptr<vk::CommandPool> drawCommandPool, std::shared_ptr<SamplerFactory> samplerFactory,
+              std::shared_ptr<vk::CommandPool> computeCommandPool, std::shared_ptr<vk::CommandPool> drawCommandPool,
+              std::shared_ptr<SamplerFactory> samplerFactory,
               std::shared_ptr<const base::AbstractScinthDef> abstractScinthDef);
     ~ScinthDef();
 

--- a/src/comp/ScinthDef.hpp
+++ b/src/comp/ScinthDef.hpp
@@ -33,7 +33,8 @@ class ShaderCompiler;
 class ScinthDef {
 public:
     ScinthDef(std::shared_ptr<vk::Device> device, std::shared_ptr<Canvas> canvas,
-              std::shared_ptr<vk::CommandPool> commandPool, std::shared_ptr<SamplerFactory> samplerFactory,
+              std::shared_ptr<vk::CommandPool> computeCommandPool,
+              std::shared_ptr<vk::CommandPool> drawCommandPool, std::shared_ptr<SamplerFactory> samplerFactory,
               std::shared_ptr<const base::AbstractScinthDef> abstractScinthDef);
     ~ScinthDef();
 
@@ -46,7 +47,8 @@ public:
     bool build(ShaderCompiler* compiler);
 
     std::shared_ptr<Canvas> canvas() const { return m_canvas; }
-    std::shared_ptr<vk::CommandPool> commandPool() const { return m_commandPool; }
+    std::shared_ptr<vk::CommandPool> computeCommandPool() const { return m_computeCommandPool; }
+    std::shared_ptr<vk::CommandPool> drawCommandPool() const { return m_drawCommandPool; }
     std::shared_ptr<const base::AbstractScinthDef> abstract() const { return m_abstract; }
     std::shared_ptr<vk::HostBuffer> vertexBuffer() const { return m_vertexBuffer; }
     std::shared_ptr<vk::HostBuffer> indexBuffer() const { return m_indexBuffer; }
@@ -64,7 +66,8 @@ private:
 
     std::shared_ptr<vk::Device> m_device;
     std::shared_ptr<Canvas> m_canvas;
-    std::shared_ptr<vk::CommandPool> m_commandPool;
+    std::shared_ptr<vk::CommandPool> m_computeCommandPool;
+    std::shared_ptr<vk::CommandPool> m_drawCommandPool;
     std::shared_ptr<SamplerFactory> m_samplerFactory;
     std::shared_ptr<const base::AbstractScinthDef> m_abstract;
     std::shared_ptr<vk::HostBuffer> m_vertexBuffer;

--- a/src/comp/ScinthDef.hpp
+++ b/src/comp/ScinthDef.hpp
@@ -54,7 +54,8 @@ public:
     const std::vector<std::shared_ptr<vk::Sampler>>& fixedSamplers() const { return m_fixedSamplers; }
     const std::vector<std::shared_ptr<vk::Sampler>>& parameterizedSamplers() const { return m_parameterizedSamplers; }
     std::shared_ptr<vk::Sampler> emptySampler() const { return m_emptySampler; }
-    std::shared_ptr<Pipeline> pipeline() const { return m_pipeline; }
+    std::shared_ptr<Pipeline> drawPipeline() const { return m_drawPipeline; }
+    std::shared_ptr<Pipeline> computePipeline() const { return m_computePipeline; }
 
 private:
     bool buildVertexData();
@@ -75,7 +76,8 @@ private:
     std::vector<std::shared_ptr<vk::Sampler>> m_fixedSamplers;
     std::vector<std::shared_ptr<vk::Sampler>> m_parameterizedSamplers;
     std::shared_ptr<vk::Sampler> m_emptySampler;
-    std::shared_ptr<Pipeline> m_pipeline;
+    std::shared_ptr<Pipeline> m_drawPipeline;
+    std::shared_ptr<Pipeline> m_computePipeline;
 };
 
 } // namespace comp

--- a/src/comp/ScinthDef.hpp
+++ b/src/comp/ScinthDef.hpp
@@ -68,6 +68,7 @@ private:
     std::shared_ptr<const base::AbstractScinthDef> m_abstract;
     std::shared_ptr<vk::HostBuffer> m_vertexBuffer;
     std::shared_ptr<vk::HostBuffer> m_indexBuffer;
+    std::shared_ptr<vk::Shader> m_computeShader;
     std::shared_ptr<vk::Shader> m_vertexShader;
     std::shared_ptr<vk::Shader> m_fragmentShader;
     VkDescriptorSetLayout m_descriptorSetLayout;

--- a/src/comp/ShaderCompiler.cpp
+++ b/src/comp/ShaderCompiler.cpp
@@ -35,6 +35,10 @@ std::unique_ptr<vk::Shader> ShaderCompiler::compile(std::shared_ptr<vk::Device> 
 
     shaderc_shader_kind shaderKind;
     switch (kind) {
+    case vk::Shader::kCompute:
+        shaderKind = shaderc_compute_shader;
+        break;
+
     case vk::Shader::kVertex:
         shaderKind = shaderc_vertex_shader;
         break;

--- a/src/comp/Window.cpp
+++ b/src/comp/Window.cpp
@@ -151,8 +151,9 @@ void Window::runDirectRendering(std::shared_ptr<comp::Compositor> compositor) {
         if (m_computeCommands) {
             VkSubmitInfo computeSubmitInfo = {};
             computeSubmitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+
             // No need to wait on anything to start this compute shader, as we already blocked the CPU on this frame
-            // being available for re-render.
+            // image being available for re-render.
             computeSubmitInfo.waitSemaphoreCount = 0;
             computeSubmitInfo.pWaitSemaphores = nullptr;
             computeSubmitInfo.pWaitDstStageMask = nullptr;
@@ -193,7 +194,8 @@ void Window::runDirectRendering(std::shared_ptr<comp::Compositor> compositor) {
         // Submits the command buffer to the queue. Won't start the buffer until the image is marked as available by
         // the imageAvailable semaphore, and when the render is finished it will signal the renderFinished semaphore
         // on the device.
-        if (vkQueueSubmit(m_device->graphicsQueue(), 1, &drawSubmitInfo, m_renderSync->frameRendering(0)) != VK_SUCCESS) {
+        if (vkQueueSubmit(m_device->graphicsQueue(), 1, &drawSubmitInfo, m_renderSync->frameRendering(0))
+            != VK_SUCCESS) {
             spdlog::critical("Window failed to submit command buffer to graphics queue.");
             break;
         }

--- a/src/comp/Window.cpp
+++ b/src/comp/Window.cpp
@@ -90,6 +90,7 @@ void Window::destroy() {
     if (!m_directRendering) {
         m_offscreen->destroy();
     }
+    m_computeCommands = nullptr;
     m_drawCommands = nullptr;
     m_renderSync->destroy();
     m_swapchain->destroy();

--- a/src/comp/Window.hpp
+++ b/src/comp/Window.hpp
@@ -85,7 +85,8 @@ private:
     // We keep the shared pointers to the command buffers until the frame is being re-rendered. This allows
     // the Compositor to change command buffers arbitrarily, and they won't get reclaimed by the system until
     // they are known finished rendering.
-    std::shared_ptr<vk::CommandBuffer> m_commandBuffers;
+    std::shared_ptr<vk::CommandBuffer> m_computeCommands;
+    std::shared_ptr<vk::CommandBuffer> m_drawCommands;
     std::atomic<bool> m_stop;
 
     // If in non realtime mode, we render to an offscreen framebuffer and blit the latest available image to the

--- a/src/vulkan/Buffer.cpp
+++ b/src/vulkan/Buffer.cpp
@@ -45,6 +45,10 @@ bool Buffer::createVulkanBuffer(bool hostAccessRequired) {
         bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
         break;
 
+    case kStorage:
+        bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        break;
+
     default:
         spdlog::error("buffer created with unsupported buffer type.");
         return false;

--- a/src/vulkan/Buffer.hpp
+++ b/src/vulkan/Buffer.hpp
@@ -15,7 +15,7 @@ class Device;
  */
 class Buffer {
 public:
-    enum Kind { kIndex, kUniform, kVertex, kStaging };
+    enum Kind { kIndex, kUniform, kVertex, kStaging, kStorage };
     Buffer(std::shared_ptr<Device> device, Kind kind, size_t size);
     virtual ~Buffer();
 
@@ -41,6 +41,7 @@ protected:
  * system architecture. But it is not likely to be slower.
  */
 class DeviceBuffer : public Buffer {
+public:
     DeviceBuffer(std::shared_ptr<Device> device, Buffer::Kind kind, size_t size);
     virtual ~DeviceBuffer();
 

--- a/src/vulkan/Device.cpp
+++ b/src/vulkan/Device.cpp
@@ -14,6 +14,7 @@ Device::Device(std::shared_ptr<Instance> instance, const DeviceInfo& deviceInfo)
     m_instance(instance),
     m_physicalDevice(deviceInfo.physicalDevice()),
     m_name(deviceInfo.name()),
+    m_computeFamilyIndex(deviceInfo.computeFamilyIndex()),
     m_graphicsFamilyIndex(deviceInfo.graphicsFamilyIndex()),
     m_presentFamilyIndex(deviceInfo.presentFamilyIndex()),
     m_numberOfMemoryHeaps(deviceInfo.numberOfMemoryHeaps()),
@@ -21,13 +22,16 @@ Device::Device(std::shared_ptr<Instance> instance, const DeviceInfo& deviceInfo)
     m_supportsSamplerAnisotropy(deviceInfo.supportsSamplerAnisotropy()),
     m_device(VK_NULL_HANDLE),
     m_allocator(VK_NULL_HANDLE),
+    m_computeQueue(VK_NULL_HANDLE),
+    m_graphicsQueue(VK_NULL_HANDLE),
     m_presentQueue(VK_NULL_HANDLE) {}
 
 Device::~Device() { destroy(); }
 
 bool Device::create(bool supportWindow) {
     std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
-    std::set<uint32_t> uniqueQueueFamilies = { static_cast<uint32_t>(m_graphicsFamilyIndex) };
+    std::set<uint32_t> uniqueQueueFamilies = { static_cast<uint32_t>(m_graphicsFamilyIndex),
+        static_cast<uint32_t>(m_computeFamilyIndex) };
     if (supportWindow) {
         uniqueQueueFamilies.insert(static_cast<uint32_t>(m_presentFamilyIndex));
     }
@@ -70,6 +74,7 @@ bool Device::create(bool supportWindow) {
         return false;
     }
 
+    vkGetDeviceQueue(m_device, m_computeFamilyIndex, 0, &m_computeQueue);
     vkGetDeviceQueue(m_device, m_graphicsFamilyIndex, 0, &m_graphicsQueue);
     if (supportWindow) {
         vkGetDeviceQueue(m_device, m_presentFamilyIndex, 0, &m_presentQueue);
@@ -121,5 +126,4 @@ bool Device::getGraphicsMemoryBudget(size_t& bytesUsedOut, size_t& bytesBudgetOu
 
 
 } // namespace vk
-
 } // namespace scin

--- a/src/vulkan/Device.cpp
+++ b/src/vulkan/Device.cpp
@@ -31,7 +31,7 @@ Device::~Device() { destroy(); }
 bool Device::create(bool supportWindow) {
     std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
     std::set<uint32_t> uniqueQueueFamilies = { static_cast<uint32_t>(m_graphicsFamilyIndex),
-        static_cast<uint32_t>(m_computeFamilyIndex) };
+                                               static_cast<uint32_t>(m_computeFamilyIndex) };
     if (supportWindow) {
         uniqueQueueFamilies.insert(static_cast<uint32_t>(m_presentFamilyIndex));
     }

--- a/src/vulkan/Device.hpp
+++ b/src/vulkan/Device.hpp
@@ -47,6 +47,8 @@ public:
 
     int graphicsFamilyIndex() const { return m_graphicsFamilyIndex; }
     int presentFamilyIndex() const { return m_presentFamilyIndex; }
+    int computeFamilyIndex() const { return m_computeFamilyIndex; }
+    VkQueue computeQueue() { return m_computeQueue; }
     VkQueue graphicsQueue() { return m_graphicsQueue; }
     VkQueue presentQueue() { return m_presentQueue; }
     bool supportsSamplerAnisotropy() const { return m_supportsSamplerAnisotropy; }
@@ -55,6 +57,7 @@ private:
     std::shared_ptr<Instance> m_instance;
     VkPhysicalDevice m_physicalDevice;
     std::string m_name;
+    int m_computeFamilyIndex;
     int m_graphicsFamilyIndex;
     int m_presentFamilyIndex;
     int m_numberOfMemoryHeaps;
@@ -62,6 +65,7 @@ private:
     bool m_supportsSamplerAnisotropy;
     VkDevice m_device;
     VmaAllocator m_allocator;
+    VkQueue m_computeQueue;
     VkQueue m_graphicsQueue;
     VkQueue m_presentQueue;
 };

--- a/src/vulkan/DeviceInfo.hpp
+++ b/src/vulkan/DeviceInfo.hpp
@@ -33,6 +33,7 @@ public:
     const char* name() const { return reinterpret_cast<const char*>(&m_properties.deviceName); }
     int presentFamilyIndex() const { return m_presentFamilyIndex; }
     int graphicsFamilyIndex() const { return m_graphicsFamilyIndex; }
+    int computeFamilyIndex() const { return m_computeFamilyIndex; }
     int numberOfMemoryHeaps() const { return m_numberOfMemoryHeaps; }
 
     bool isSwiftShader() const;
@@ -51,6 +52,7 @@ private:
     VkPhysicalDeviceFeatures m_features;
     int m_presentFamilyIndex;
     int m_graphicsFamilyIndex;
+    int m_computeFamilyIndex;
     int m_numberOfMemoryHeaps;
     bool m_supportsWindow;
     bool m_supportsMemoryBudget;

--- a/src/vulkan/Shader.hpp
+++ b/src/vulkan/Shader.hpp
@@ -12,7 +12,7 @@ class Device;
 
 class Shader {
 public:
-    enum Kind { kVertex, kFragment };
+    enum Kind { kCompute, kVertex, kFragment };
     Shader(Kind kind, std::shared_ptr<Device> device, const std::string& entryPoint);
     ~Shader();
 

--- a/tools/TestScripts/testManifest.yaml
+++ b/tools/TestScripts/testManifest.yaml
@@ -218,3 +218,18 @@
   captureTimes: [ 1 ]
   free: [ "alphaBlue" ]
   assertAllFree: true
+- name: "Frame Rate oscillator"
+  category: "frame"
+  comment: "Test a global oscillator running in frame rate VGen with parameters and intrinsics"
+  shortName: "frOsc"
+  scinthDef: "{ |k = 7.0|
+    var phaseMul = VSinOsc.fr(freq: 0.3, mul: k, add: 1.0);
+    BWOut.pr(Step.pr(VSinOsc.pr(freq: 0.1, phase: Length.pr(NormPos.pr) * (5 + phaseMul)), 0.5));
+  }"
+  captureTimes: [ 1, 1, 1, 1 ]
+  parameters:
+      - "none"
+      - k: 10
+      - k: 60
+      - k: 150
+


### PR DESCRIPTION
## Purpose and motivation

Continuing work on #60, adds preliminary support for frame-rate VGens, those are VGens that run once per Scinth instance per frame.

## Implementation

Adds a compute stage that is invoked to execute any frame-rate VGens and then copy computation output to a buffer for consumption by the draw stage. This required more refactors to AbstractScinthDef all the way to Window and Offscreen to support compute command buffer submission as part of the run loop.

## Types of changes

* Behaviour change
* Enhancement

## Status

- [x] This PR is ready for review
- [x] Unit tests added
- [x] Unit tests are passing
