### PR TITLE
Add crash reporting to MacOS

### DIFF
--- a/.travis/before-script-osx.sh
+++ b/.travis/before-script-osx.sh
@@ -4,7 +4,6 @@ touch $TRAVIS_BUILD_DIR/bin/disable_auto_install
 cd $TRAVIS_BUILD_DIR/build
 
 cmake -G Xcode                                                                                                         \
-    -DSCIN_USE_CRASHPAD=OFF                                                                                            \
     -DPYTHON_EXECUTABLE=`which python3`                                                                                \
     -DSCIN_BUILD_DOCS=OFF                                                                                              \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13                                                                                \

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -3,8 +3,8 @@
 XCPRETTY='xcpretty --simple --no-utf --no-color'
 
 cd $TRAVIS_BUILD_DIR/build
-cmake --build . --config RelWithDebInfo | $XCPRETTY
-cmake --build . --config RelWithDebInfo --target dump_symbols
-cmake --install .
-cmake --build . --target compare_images --config RelWithDebInfo
+cmake --build . --config RelWithDebInfo | $XCPRETTY || exit 1
+cmake --build . --config RelWithDebInfo --target dump_symbols || exit 2
+cmake --install . || exit 3
+cmake --build . --target compare_images --config RelWithDebInfo || exit 4
 

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -3,7 +3,8 @@
 XCPRETTY='xcpretty --simple --no-utf --no-color'
 
 cd $TRAVIS_BUILD_DIR/build
-cmake --build . --config Release | $XCPRETTY
+cmake --build . --config RelWithDebInfo | $XCPRETTY
+cmake --build . --config RelWithDebInfo --target dump_symbols
 cmake --install .
-cmake --build . --target compare_images --config Release
+cmake --build . --target compare_images --config RelWithDebInfo
 

--- a/.travis/script-osx.sh
+++ b/.travis/script-osx.sh
@@ -5,6 +5,6 @@ XCPRETTY='xcpretty --simple --no-utf --no-color'
 cd $TRAVIS_BUILD_DIR/build
 cmake --build . --config RelWithDebInfo | $XCPRETTY || exit 1
 cmake --build . --config RelWithDebInfo --target dump_symbols || exit 2
-cmake --install . || exit 3
+cmake --install . --config RelWithDebInfo || exit 3
 cmake --build . --target compare_images --config RelWithDebInfo || exit 4
 

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -180,11 +180,18 @@ ScinServer {
 		});
 
 		statusPoller.serverBooting = true;
-		if (thisProcess.platform.name === 'windows', {
-			commandLine = scinBinaryPath + options.asOptionsString();
-		}, {
-			commandLine = scinBinaryPath.shellQuote + options.asOptionsString();
-		});
+		Platform.case(
+			\osx, {
+				commandLine = scinBinaryPath.shellQuote + options.asOptionsString() + '--crashpadHandlerPath='
+				++ Scintillator.binDir +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "crashpad_handler";
+			},
+			\linux, {
+				commandLine = scinBinaryPath.shellQuote + options.asOptionsString();
+			},
+			\windows, {
+				commandLine = scinBinaryPath + options.asOptionsString();
+			}
+		);
 
 		scinPid = commandLine.unixCmd({ |exitCode, exitPid|
 			if (exitCode == 0, {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -389,25 +389,19 @@ if (SCIN_USE_CRASHPAD)
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/test/libtest.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/test/libgoogletest_main.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/test/libgooglemock_main.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libmig_output.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgooglemock.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgoogletest.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgoogletest_main.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgooglemock_main.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+
+            "-framework AppKit"
+            "-framework Security"
+            bsm
         )
     elseif(UNIX)
         target_link_libraries(scinsynth
-            # TODO: use globbing to just pick up all the .a files and then include them twice.
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
@@ -417,7 +411,7 @@ if (SCIN_USE_CRASHPAD)
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
+            #${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
 
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
@@ -429,23 +423,24 @@ if (SCIN_USE_CRASHPAD)
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
+            #${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
+        )
+        # analysis tool is linux-only
+        add_custom_target(log_crashes
+            ${PYTHON_EXECUTABLE} tools/minidump-stackwalk.py --database .crash_reports --fail_with_nonempty_database
+            DEPENDS scinsynth
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            VERBATIM
         )
     endif()
     add_custom_target(dump_symbols
-        ${PYTHON_EXECUTABLE} tools/prepare-symbol-dump.py
+        ${PYTHON_EXECUTABLE} tools/prepare-symbol-dump.py $<TARGET_FILE:scinsynth>
         DEPENDS scinsynth
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         VERBATIM
     )
     target_compile_definitions(scinsynth PRIVATE SCIN_USE_CRASHPAD)
-    add_custom_target(log_crashes
-        ${PYTHON_EXECUTABLE} tools/minidump-stackwalk.py --database .crash_reports --fail_with_nonempty_database
-        DEPENDS scinsynth
-        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-        VERBATIM
-    )
 endif()
 
 file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
@@ -471,6 +466,11 @@ if (APPLE)
     install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/macos/Resources/vulkan"
         DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Resources"
     )
+    if (SCIN_USE_CRASHPAD)
+        install(PROGRAMS "${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/crashpad_handler"
+            DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/MacOS"
+        )
+    endif()
     list(APPEND SCIN_MACOS_LIBS "${SCIN_EXT_INSTALL_DIR}/lib")
     list(APPEND SCIN_MACOS_LIBS "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Frameworks")
     install(CODE "

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,32 +384,55 @@ if (SCIN_USE_CRASHPAD)
         ${SCIN_EXT_INSTALL_DIR}/crashpad
         ${SCIN_EXT_INSTALL_DIR}/crashpad/third_party/mini_chromium/mini_chromium
     )
-    target_link_libraries(scinsynth
-        # TODO: use globbing to just pick up all the .a files and then include them twice.
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
+    if (APPLE)
+        target_link_libraries(scinsynth
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/test/libtest.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/test/libgoogletest_main.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/test/libgooglemock_main.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libmig_output.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgooglemock.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgoogletest.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgoogletest_main.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/googletest/libgooglemock_main.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+        )
+    elseif(UNIX)
+        target_link_libraries(scinsynth
+            # TODO: use globbing to just pick up all the .a files and then include them twice.
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
 
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
-    )
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
+            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
+        )
+    endif()
     add_custom_target(dump_symbols
         ${PYTHON_EXECUTABLE} tools/prepare-symbol-dump.py
         DEPENDS scinsynth

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -411,7 +411,6 @@ if (SCIN_USE_CRASHPAD)
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            #${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
 
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
@@ -423,10 +422,9 @@ if (SCIN_USE_CRASHPAD)
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            #${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libtest_support.a
             ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
         )
-        # analysis tool is linux-only
+        # analysis tool is Linux-only
         add_custom_target(log_crashes
             ${PYTHON_EXECUTABLE} tools/minidump-stackwalk.py --database .crash_reports --fail_with_nonempty_database
             DEPENDS scinsynth

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -70,12 +70,14 @@ bool CrashReporter::openDatabase() {
 
 void CrashReporter::closeDatabase() { m_database = nullptr; }
 
+#if __linux__
 void CrashReporter::dumpWithoutCrash() {
     spdlog::info("generating minidump without crash.");
     crashpad::NativeCPUContext context;
     crashpad::CaptureContext(&context);
     m_client->DumpWithoutCrash(&context);
 }
+#endif
 
 int CrashReporter::logCrashReports() {
     if (!openDatabase())

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -70,14 +70,14 @@ bool CrashReporter::openDatabase() {
 
 void CrashReporter::closeDatabase() { m_database = nullptr; }
 
-#if __linux__
+#    if __linux__
 void CrashReporter::dumpWithoutCrash() {
     spdlog::info("generating minidump without crash.");
     crashpad::NativeCPUContext context;
     crashpad::CaptureContext(&context);
     m_client->DumpWithoutCrash(&context);
 }
-#endif
+#    endif
 
 int CrashReporter::logCrashReports() {
     if (!openDatabase())

--- a/src/infra/CrashReporter.hpp
+++ b/src/infra/CrashReporter.hpp
@@ -54,10 +54,12 @@ public:
      */
     int logCrashReports();
 
+#if __linux__
     /*! Requests the handler to generate a minidump stack trace and all accessory information in a crash report.
-     * Useful for testing the crash reporting system.
+     * Useful for testing the crash reporting system. Linux only.
      */
     void dumpWithoutCrash();
+#endif
 
     /*! Mark the provided crash report as ready for upload by the handler process.
      *

--- a/src/infra/CrashReporter.hpp
+++ b/src/infra/CrashReporter.hpp
@@ -54,12 +54,12 @@ public:
      */
     int logCrashReports();
 
-#if __linux__
+#        if __linux__
     /*! Requests the handler to generate a minidump stack trace and all accessory information in a crash report.
      * Useful for testing the crash reporting system. Linux only.
      */
     void dumpWithoutCrash();
-#endif
+#        endif
 
     /*! Mark the provided crash report as ready for upload by the handler process.
      *

--- a/src/osc/commands/CreateCrashReport.cpp
+++ b/src/osc/commands/CreateCrashReport.cpp
@@ -14,7 +14,7 @@ CreateCrashReport::CreateCrashReport(osc::Dispatcher* dispatcher): Command(dispa
 CreateCrashReport::~CreateCrashReport() {}
 
 void CreateCrashReport::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
-#if defined(SCIN_USE_CRASHPAD)
+#if __linux__ && defined(SCIN_USE_CRASHPAD)
     m_dispatcher->crashReporter()->dumpWithoutCrash();
 #else
     spdlog::warn("crash report requested but build has crashpad disabled.");

--- a/src/osc/commands/CreateCrashReport.cpp
+++ b/src/osc/commands/CreateCrashReport.cpp
@@ -18,6 +18,8 @@ void CreateCrashReport::processMessage(int argc, lo_arg** argv, const char* type
     m_dispatcher->crashReporter()->dumpWithoutCrash();
 #else
     spdlog::warn("crash report requested but build has crashpad disabled.");
+    int* foo = nullptr;
+    spdlog::error("deref null: {}", *foo);
 #endif
 }
 

--- a/tools/code-sign-macos.py
+++ b/tools/code-sign-macos.py
@@ -47,9 +47,11 @@ def main(argv):
             'bin/scinsynth.app/Contents/entitlements.plist', '--sign', signIdentity]
     runtime = ['--options', 'runtime']
 
-    # Sign app and binary.
+    # Sign app, binary, and crashpad handler (if present)
     subprocess.run(codesign + runtime + ['bin/scinsynth.app'], check=True)
     subprocess.run(codesign + runtime + ['bin/scinsynth.app/Contents/MacOS/scinsynth'], check=True)
+    if os.path.exists('bin/scinsynth.app/Contents/MacOS/crashpad_handler'):
+        subprocess.run(codesign + runtime + ['bin/scinsynth.app/Contents/MacOS/crashpad_handler'], check=True)
 
     # Sign all dynamic libraries.
     dylibs = subprocess.run(['find', 'bin/scinsynth.app', '-type', 'f', '-name', '*.dylib'], check=True,

--- a/tools/fetch-binary-deps.py
+++ b/tools/fetch-binary-deps.py
@@ -42,6 +42,7 @@ def main(argv):
         needed_deps.append('crashpad-ext')
     elif platform.system() == 'Darwin':
         os_name = 'osx'
+        needed_deps.append('crashpad-ext')
     elif platform.system() == 'Windows':
         os_name = 'windows'
     else:

--- a/tools/prepare-symbol-dump.py
+++ b/tools/prepare-symbol-dump.py
@@ -15,6 +15,7 @@
 # c) creates the dump_id subdirectory, copies the symbol file into it
 
 import os
+import platform
 import select
 import shutil
 import subprocess
@@ -26,8 +27,19 @@ def main(argv):
         print('Please run this script from the Scintillator Quark root directory.')
         sys.exit(1)
 
+    if len(argv) < 1:
+        print ('Usage: python3 prepare-symbol-dump.py <path to scintillator binary>')
+        sys.exit(1)
+
     print('extracting symbols from scinsynth')
-    dump_syms = subprocess.run(['build/install-ext/bin/dump_syms', '-v', 'build/src/scinsynth'], stdout=subprocess.PIPE)
+    dump_syms_command = ['build/install-ext/bin/dump_syms']
+    if platform.system() == 'Linux':
+        dump_syms_command.append('-v')
+        dump_syms_command.append(argv[0])
+    elif platform.system() == 'Darwin':
+        dump_syms_command.append(argv[0])
+
+    dump_syms = subprocess.run(dump_syms_command, stdout=subprocess.PIPE)
     # syms is typically ~10MB of text data
     syms = dump_syms.stdout.decode('utf-8')
 


### PR DESCRIPTION
## Purpose and motivation

Continuation of work in #137, extends the Crashpad minidump collection and upload, plus the symbol collection during compilation, to MacOS.

## Implementation

Some work on crashpad-ext to get the dependencies compiling correctly, and then patching of scinserver for the MacOS-specific parts of the crash reporting.

## Types of changes

* Enhancement

## Status

- [x] This PR is ready for review
