### PR TITLE
adds crash reporting to windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,5 +76,5 @@ deploy:
   verbose: true
   on:
     condition: "$DO_COVERAGE = false"
-    branch: master
+    all_branches: true
 

--- a/.travis/before-deploy-windows.sh
+++ b/.travis/before-deploy-windows.sh
@@ -14,3 +14,8 @@ else
     powershell 'compress-archive '$SCIN_BIN_PATH' '$SCIN_ZIP_PATH
     certutil -hashfile $HOME/releases/$TRAVIS_TAG/scinsynth-w64.zip SHA256 | sed -n '2,2p;2q' > $HOME/releases/$TRAVIS_TAG/scinsynth-w64.zip.sha256
 fi
+
+# symbol upload
+mkdir -p $HOME/symbols
+cp $TRAVIS_BUILD_DIR/build/symbols-scinsynth-*.gz $HOME/symbols
+

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -2,8 +2,7 @@
 
 touch $TRAVIS_BUILD_DIR/bin/disable_auto_install
 cd $TRAVIS_BUILD_DIR/build
-cmake -DSCIN_USE_CRASHPAD=OFF                                                                                          \
-      -DSCIN_BUILD_DOCS=OFF                                                                                            \
+cmake -DSCIN_BUILD_DOCS=OFF                                                                                            \
       -DSCIN_SCLANG=$TRAVIS_HOME/sclang/SuperCollider/sclang.exe                                                       \
       -DPYTHON_EXECUTABLE=/c/Python38/python.exe                                                                       \
       -DCMAKE_GENERATOR_PLATFORM=x64                                                                                   \

--- a/.travis/script-windows.sh
+++ b/.travis/script-windows.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 cd $TRAVIS_BUILD_DIR/build
-cmake --build . --config Release
-cmake --install . --config Release
+cmake --build . --config RelWithDebInfo
+cmake --build . --config RelWithDebInfo --target dump_symbols
+cmake --install . --config RelWithDebInfo
 
 echo "Configuring host machine to use Swiftshader as a Vulkan device"
 powershell 'New-Item -Path "HKLM:\SOFTWARE\Khronos\Vulkan" -Name Drivers'
@@ -10,5 +11,5 @@ export SWSHADER_PATH=`cygpath -w $TRAVIS_BUILD_DIR`'\bin\scinsynth-w64\vulkan\ic
 echo "Setting Swiftshader path to $SWSHADER_PATH"
 powershell 'New-ItemProperty -PATH "HKLM:\SOFTWARE\Khronos\Vulkan\Drivers" -Name "'$SWSHADER_PATH'" -Value "0" -PropertyType "DWORD"'
 
-cmake --build . --config Release --target compare_images
+cmake --build . --config RelWithDebInfo --target compare_images
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED)
 
 option(SCIN_BUILD_DOCS "Add docs build target to build C++ documentation with Doxygen" ON)
-option(SCIN_USE_CRASHPAD "Add crash detection and reporting to scinsynth" ON)
 
 # If this is a git checkout we can extract the git hash and branch. This code copied verbatim or close to it from the
 # SuperCollider CMake files.

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -189,7 +189,8 @@ ScinServer {
 				commandLine = scinBinaryPath.shellQuote + options.asOptionsString();
 			},
 			\windows, {
-				commandLine = scinBinaryPath + options.asOptionsString();
+				commandLine = scinBinaryPath + options.asOptionsString() + '--crashpadHandlerPath='
+				++ Scintillator.binDir +/+ "scinsynth-w64" +/+ "crashpad_handler.com";
 			}
 		);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,10 @@ elseif(UNIX)
     target_link_libraries(scintillator_base
         stdc++fs
     )
+elseif(WIN32)
+    set_property(TARGET scintillator_base PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreadedDLL"
+    )
 endif()
 
 #### Unit Testing for Core Files
@@ -91,6 +95,10 @@ target_link_libraries(run_unittests
 if (UNIX AND NOT APPLE)
     target_link_libraries(run_unittests
         stdc++fs
+    )
+elseif(WIN32)
+    set_property(TARGET run_unittests PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreadedDLL"
     )
 endif()
 
@@ -280,6 +288,9 @@ elseif(UNIX)
     )
 elseif(WIN32)
     add_executable(scinsynth ${scintillator_synth_files})
+    set_property(TARGET scinsynth PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreadedDLL"
+    )
 endif()
 
 # Force using the locally sourced libraries as opposed to system libs
@@ -379,67 +390,78 @@ add_dependencies(scinsynth
     liblo-install
 )
 
-if (SCIN_USE_CRASHPAD)
-    target_include_directories(scinsynth PRIVATE
-        ${SCIN_EXT_INSTALL_DIR}/crashpad
-        ${SCIN_EXT_INSTALL_DIR}/crashpad/third_party/mini_chromium/mini_chromium
+target_include_directories(scinsynth PRIVATE
+    ${SCIN_EXT_INSTALL_DIR}/crashpad
+    ${SCIN_EXT_INSTALL_DIR}/crashpad/third_party/mini_chromium/mini_chromium
+)
+if (APPLE)
+    target_link_libraries(scinsynth
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libmig_output.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+
+        "-framework AppKit"
+        "-framework Security"
+        bsm
     )
-    if (APPLE)
-        target_link_libraries(scinsynth
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libmig_output.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+elseif(UNIX)
+    target_link_libraries(scinsynth
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
 
-            "-framework AppKit"
-            "-framework Security"
-            bsm
-        )
-    elseif(UNIX)
-        target_link_libraries(scinsynth
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
-
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
-            ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
-        )
-        # analysis tool is Linux-only
-        add_custom_target(log_crashes
-            ${PYTHON_EXECUTABLE} tools/minidump-stackwalk.py --database .crash_reports --fail_with_nonempty_database
-            DEPENDS scinsynth
-            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-            VERBATIM
-        )
-    endif()
-    add_custom_target(dump_symbols
-        ${PYTHON_EXECUTABLE} tools/prepare-symbol-dump.py $<TARGET_FILE:scinsynth>
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/libbase.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/libcompat.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libformat.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libtest_support.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/libminidump.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/libclient.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/libutil.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libsnapshot.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/libcontext.a
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/handler/libhandler.a
+    )
+    # analysis tool is Linux-only
+    add_custom_target(log_crashes
+        ${PYTHON_EXECUTABLE} tools/minidump-stackwalk.py --database .crash_reports --fail_with_nonempty_database
         DEPENDS scinsynth
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         VERBATIM
     )
-    target_compile_definitions(scinsynth PRIVATE SCIN_USE_CRASHPAD)
+else() # assumption this is windows
+    target_link_libraries(scinsynth
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/client/client.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/compat/compat.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/format.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/minidump/minidump.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/context.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/snapshot/snapshot.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/getopt/getopt.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/mini_chromium/mini_chromium/base/base.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/third_party/zlib/zlib.lib
+        ${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/obj/util/util.lib
+    )
 endif()
+
+add_custom_target(dump_symbols
+    ${PYTHON_EXECUTABLE} tools/prepare-symbol-dump.py $<TARGET_FILE:scinsynth>
+    DEPENDS scinsynth
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    VERBATIM
+)
 
 file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
 if (APPLE)
@@ -464,11 +486,9 @@ if (APPLE)
     install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/macos/Resources/vulkan"
         DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Resources"
     )
-    if (SCIN_USE_CRASHPAD)
-        install(PROGRAMS "${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/crashpad_handler"
-            DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/MacOS"
-        )
-    endif()
+    install(PROGRAMS "${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/crashpad_handler"
+        DESTINATION "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/MacOS"
+    )
     list(APPEND SCIN_MACOS_LIBS "${SCIN_EXT_INSTALL_DIR}/lib")
     list(APPEND SCIN_MACOS_LIBS "${PROJECT_SOURCE_DIR}/bin/scinsynth.app/Contents/Frameworks")
     install(CODE "
@@ -520,12 +540,10 @@ elseif(UNIX)
     install(DIRECTORY "${SCIN_EXT_INSTALL_DIR}/share/vulkan/icd.d"
         DESTINATION "${SCIN_APPDIR}/usr/share/vulkan"
     )
-    if (SCIN_USE_CRASHPAD)
-        # Copy the crash report handler binary
-        install(PROGRAMS "${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/crashpad_handler"
-            DESTINATION "${SCIN_APPDIR}/usr/bin"
-        )
-    endif()
+    # Copy the crash report handler binary
+    install(PROGRAMS "${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/crashpad_handler"
+        DESTINATION "${SCIN_APPDIR}/usr/bin"
+    )
     # Now invoke linuxdeploy to assemble AppImage. Need to provide a path to LD_LIBRARY_PATH environment variable so the
     # tool knows where to look for the dependent libraries.
     install(CODE "
@@ -559,6 +577,10 @@ elseif(WIN32)
         "${SCIN_EXT_INSTALL_DIR}/lib/VkLayer_khronos_validation.dll"
         "${SCIN_EXT_INSTALL_DIR}/lib/VkLayer_khronos_validation.json"
         DESTINATION "${SCIN_WIN64_DIR}/vulkan/explicit_layer.d"
+    )
+    install(PROGRAMS
+         "${SCIN_EXT_INSTALL_DIR}/crashpad/out/Default/crashpad_handler.com"
+          DESTINATION "${SCIN_WIN64_DIR}"
     )
 endif()
 

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -1,4 +1,3 @@
-#if defined(SCIN_USE_CRASHPAD)
 #    include "infra/CrashReporter.hpp"
 
 #    include "infra/Version.hpp"
@@ -32,9 +31,10 @@ void logReport(const crashpad::CrashReportDatabase::Report& report) {
 
 namespace scin { namespace infra {
 
-CrashReporter::CrashReporter(const std::string& crashpadHandlerPath, const std::string& databasePath):
-    m_crashpadHandlerPath(crashpadHandlerPath),
-    m_databasePath(databasePath),
+CrashReporter::CrashReporter(const fs::path& handler, const fs::path& database, const fs::path& metrics):
+    m_handlerPath(handler),
+    m_databasePath(database),
+    m_metricsPath(metrics),
     m_client(new crashpad::CrashpadClient()) {}
 
 CrashReporter::~CrashReporter() {}
@@ -46,10 +46,20 @@ bool CrashReporter::startCrashHandler() {
     metadata["commit"] = kScinCompleteHash;
     metadata["branch"] = kScinBranch;
 
-    return m_client->StartHandler(base::FilePath(m_crashpadHandlerPath), base::FilePath(m_databasePath),
-                                  base::FilePath(""), // Metrics path
+#if (WIN32)
+    // TODO: crash reporting seems to be working despite the header comments in crashpad_client.h stating that on
+    // windows a named IPC pipe call must also be made after startup. Investigate the inconsistency.
+    return m_client->StartHandler(base::FilePath(m_handlerPath.wstring()),
+                                  base::FilePath(m_databasePath.wstring()),
+                                  base::FilePath(m_metricsPath.wstring()),
                                   kGargamelleURL, metadata, std::vector<std::string>(), false, false,
                                   std::vector<base::FilePath>());
+#else
+    return m_client->StartHandler(base::FilePath(m_handlerPath.string()), base::FilePath(m_databasePath.string()),
+                       base::FilePath(m_metricsPath.string()),
+                       kGargamelleURL, metadata, std::vector<std::string>(), false, false,
+                       std::vector<base::FilePath>());
+#endif
 }
 
 
@@ -72,12 +82,19 @@ void CrashReporter::closeDatabase() { m_database = nullptr; }
 
 #    if __linux__
 void CrashReporter::dumpWithoutCrash() {
-    spdlog::info("generating minidump without crash.");
+    spdlog::info("generating linux minidump without crash.");
     crashpad::NativeCPUContext context;
-    crashpad::CaptureContext(&context);
-    m_client->DumpWithoutCrash(&context);
+    crashpad::CaptureContext(context);
+    m_client->DumpWithoutCrash(context);
 }
-#    endif
+#elif (WIN32)
+void CrashReporter::dumpWithoutCrash() {
+    spdlog::info("generating windows minidump without crash.");
+    CONTEXT context;
+    crashpad::CaptureContext(&context);
+    m_client->DumpWithoutCrash(context);
+}
+#endif
 
 int CrashReporter::logCrashReports() {
     if (!openDatabase())
@@ -203,4 +220,3 @@ bool CrashReporter::uploadAllCrashReports() {
 
 } // namespace infra
 } // namespace scin
-#endif // SCIN_USE_CRASHPAD

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -1,20 +1,20 @@
-#    include "infra/CrashReporter.hpp"
+#include "infra/CrashReporter.hpp"
 
-#    include "infra/Version.hpp"
+#include "infra/Version.hpp"
 
-#    include <client/crash_report_database.h>
-#    include <client/crashpad_client.h>
-#    include <client/settings.h>
-#    include <fmt/core.h>
-#    include <spdlog/spdlog.h>
-#    include <util/misc/capture_context.h>
-#    include <util/misc/uuid.h>
+#include <client/crash_report_database.h>
+#include <client/crashpad_client.h>
+#include <client/settings.h>
+#include <fmt/core.h>
+#include <spdlog/spdlog.h>
+#include <util/misc/capture_context.h>
+#include <util/misc/uuid.h>
 
-#    include <array>
-#    include <map>
-#    include <string>
-#    include <time.h>
-#    include <vector>
+#include <array>
+#include <map>
+#include <string>
+#include <time.h>
+#include <vector>
 
 namespace {
 
@@ -49,16 +49,13 @@ bool CrashReporter::startCrashHandler() {
 #if (WIN32)
     // TODO: crash reporting seems to be working despite the header comments in crashpad_client.h stating that on
     // windows a named IPC pipe call must also be made after startup. Investigate the inconsistency.
-    return m_client->StartHandler(base::FilePath(m_handlerPath.wstring()),
-                                  base::FilePath(m_databasePath.wstring()),
-                                  base::FilePath(m_metricsPath.wstring()),
-                                  kGargamelleURL, metadata, std::vector<std::string>(), false, false,
-                                  std::vector<base::FilePath>());
+    return m_client->StartHandler(base::FilePath(m_handlerPath.wstring()), base::FilePath(m_databasePath.wstring()),
+                                  base::FilePath(m_metricsPath.wstring()), kGargamelleURL, metadata,
+                                  std::vector<std::string>(), false, false, std::vector<base::FilePath>());
 #else
     return m_client->StartHandler(base::FilePath(m_handlerPath.string()), base::FilePath(m_databasePath.string()),
-                       base::FilePath(m_metricsPath.string()),
-                       kGargamelleURL, metadata, std::vector<std::string>(), false, false,
-                       std::vector<base::FilePath>());
+                                  base::FilePath(m_metricsPath.string()), kGargamelleURL, metadata,
+                                  std::vector<std::string>(), false, false, std::vector<base::FilePath>());
 #endif
 }
 
@@ -80,12 +77,12 @@ bool CrashReporter::openDatabase() {
 
 void CrashReporter::closeDatabase() { m_database = nullptr; }
 
-#    if __linux__
+#if __linux__
 void CrashReporter::dumpWithoutCrash() {
     spdlog::info("generating linux minidump without crash.");
     crashpad::NativeCPUContext context;
-    crashpad::CaptureContext(context);
-    m_client->DumpWithoutCrash(context);
+    crashpad::CaptureContext(&context);
+    m_client->DumpWithoutCrash(&context);
 }
 #elif (WIN32)
 void CrashReporter::dumpWithoutCrash() {

--- a/src/infra/CrashReporter.hpp
+++ b/src/infra/CrashReporter.hpp
@@ -1,10 +1,10 @@
-#    ifndef SRC_INFRA_CRASH_REPORTER_HPP_
-#        define SRC_INFRA_CRASH_REPORTER_HPP_
+#ifndef SRC_INFRA_CRASH_REPORTER_HPP_
+#define SRC_INFRA_CRASH_REPORTER_HPP_
 
 #include "base/FileSystem.hpp"
 
-#        include <memory>
-#        include <string>
+#include <memory>
+#include <string>
 
 namespace crashpad {
 class CrashpadClient;
@@ -55,12 +55,12 @@ public:
      */
     int logCrashReports();
 
-#        if __linux__ || WIN32
+#if __linux__ || WIN32
     /*! Requests the handler to generate a minidump stack trace and all accessory information in a crash report.
      * Useful for testing the crash reporting system. Linux only.
      */
     void dumpWithoutCrash();
-#        endif
+#endif
 
     /*! Mark the provided crash report as ready for upload by the handler process.
      *
@@ -87,4 +87,4 @@ private:
 } // namespace infra
 } // namespace scin
 
-#    endif // SRC_INFRA_CRASH_REPORTER_HPP_
+#endif // SRC_INFRA_CRASH_REPORTER_HPP_

--- a/src/infra/CrashReporter.hpp
+++ b/src/infra/CrashReporter.hpp
@@ -1,6 +1,7 @@
-#if defined(SCIN_USE_CRASHPAD)
 #    ifndef SRC_INFRA_CRASH_REPORTER_HPP_
 #        define SRC_INFRA_CRASH_REPORTER_HPP_
+
+#include "base/FileSystem.hpp"
 
 #        include <memory>
 #        include <string>
@@ -20,11 +21,11 @@ class CrashReporter {
 public:
     /*! CrashReporter constructor.
      *
-     * \param crashpadHandlerPath The path to the executable to run as the crashpad handler.
-     * \param databasePath A file path to the crash report database root directory. If it does not exist it will be
-     *        created.
+     * \param handler The path to the executable to run as the crashpad handler.
+     * \param database A path to the crash report database root directory. If it does not exist it will be created.
+     * \param metrics A path to the metrics database root directory. If it does not exist it will be created.
      */
-    CrashReporter(const std::string& crashpadHandlerPath, const std::string& databasePath);
+    CrashReporter(const fs::path& handler, const fs::path& database, const fs::path& metrics);
 
     /*! CrashReporter destructor. Will disable crash reporting when executed, so should be deferred as late as possible
      * in process exit.
@@ -54,7 +55,7 @@ public:
      */
     int logCrashReports();
 
-#        if __linux__
+#        if __linux__ || WIN32
     /*! Requests the handler to generate a minidump stack trace and all accessory information in a crash report.
      * Useful for testing the crash reporting system. Linux only.
      */
@@ -75,8 +76,9 @@ public:
     bool uploadAllCrashReports();
 
 private:
-    std::string m_crashpadHandlerPath;
-    std::string m_databasePath;
+    fs::path m_handlerPath;
+    fs::path m_databasePath;
+    fs::path m_metricsPath;
 
     std::unique_ptr<crashpad::CrashReportDatabase> m_database;
     std::unique_ptr<crashpad::CrashpadClient> m_client;
@@ -86,4 +88,3 @@ private:
 } // namespace scin
 
 #    endif // SRC_INFRA_CRASH_REPORTER_HPP_
-#endif // SCIN_USE_CRASHPAD

--- a/src/osc/Dispatcher.cpp
+++ b/src/osc/Dispatcher.cpp
@@ -61,8 +61,7 @@ Dispatcher::Dispatcher(std::shared_ptr<infra::Logger> logger, std::shared_ptr<co
     m_udpThread(nullptr),
     m_udpServer(nullptr),
     m_quitOrigin(nullptr),
-    m_dumpOSC(false) {
-}
+    m_dumpOSC(false) {}
 
 Dispatcher::~Dispatcher() { destroy(); }
 

--- a/src/osc/Dispatcher.cpp
+++ b/src/osc/Dispatcher.cpp
@@ -44,17 +44,10 @@
 
 namespace scin { namespace osc {
 
-#if defined(SCIN_USE_CRASHPAD)
 Dispatcher::Dispatcher(std::shared_ptr<infra::Logger> logger, std::shared_ptr<comp::Async> async,
                        std::shared_ptr<base::Archetypes> archetypes, std::shared_ptr<comp::Compositor> compositor,
                        std::shared_ptr<comp::Offscreen> offscreen, std::shared_ptr<const comp::FrameTimer> frameTimer,
                        std::function<void()> quitHandler, std::shared_ptr<infra::CrashReporter> crashReporter):
-#else
-Dispatcher::Dispatcher(std::shared_ptr<infra::Logger> logger, std::shared_ptr<comp::Async> async,
-                       std::shared_ptr<base::Archetypes> archetypes, std::shared_ptr<comp::Compositor> compositor,
-                       std::shared_ptr<comp::Offscreen> offscreen, std::shared_ptr<const comp::FrameTimer> frameTimer,
-                       std::function<void()> quitHandler):
-#endif
     m_logger(logger),
     m_async(async),
     m_archetypes(archetypes),
@@ -62,9 +55,7 @@ Dispatcher::Dispatcher(std::shared_ptr<infra::Logger> logger, std::shared_ptr<co
     m_offscreen(offscreen),
     m_frameTimer(frameTimer),
     m_quitHandler(quitHandler),
-#if defined(SCIN_USE_CRASHPAD)
     m_crashReporter(crashReporter),
-#endif
     m_tcpThread(nullptr),
     m_tcpServer(nullptr),
     m_udpThread(nullptr),

--- a/src/osc/Dispatcher.hpp
+++ b/src/osc/Dispatcher.hpp
@@ -49,17 +49,10 @@ public:
      *        terminate the scinsynth program.
      * \param crashReporter The crash reporting object, for requesting minidumps.
      */
-#if defined(SCIN_USE_CRASHPAD)
     Dispatcher(std::shared_ptr<infra::Logger> logger, std::shared_ptr<comp::Async> async,
                std::shared_ptr<base::Archetypes> archetypes, std::shared_ptr<comp::Compositor> compositor,
                std::shared_ptr<comp::Offscreen> offscreen, std::shared_ptr<const comp::FrameTimer> frameTimer,
                std::function<void()> quitHandler, std::shared_ptr<infra::CrashReporter> crashReporter);
-#else
-    Dispatcher(std::shared_ptr<infra::Logger> logger, std::shared_ptr<comp::Async> async,
-               std::shared_ptr<base::Archetypes> archetypes, std::shared_ptr<comp::Compositor> compositor,
-               std::shared_ptr<comp::Offscreen> offscreen, std::shared_ptr<const comp::FrameTimer> frameTimer,
-               std::function<void()> quitHandler);
-#endif
     ~Dispatcher();
 
     /*! Bind the TCP and UDP ports and set up the data structues to dispatch OSC commands for handling.
@@ -122,9 +115,8 @@ public:
     std::shared_ptr<comp::Compositor> compositor() { return m_compositor; }
     std::shared_ptr<comp::Offscreen> offscreen() { return m_offscreen; }
     std::shared_ptr<const comp::FrameTimer> frameTimer() { return m_frameTimer; }
-#if defined(SCIN_USE_CRASHPAD)
     std::shared_ptr<infra::CrashReporter> crashReporter() { return m_crashReporter; }
-#endif
+
     void callQuitHandler(std::shared_ptr<Address> quitOrigin);
     void setDumpOSC(bool enable) { m_dumpOSC = enable; }
     void processMessageFrom(lo_address address, std::shared_ptr<BlobMessage> onCompletion);
@@ -142,9 +134,7 @@ private:
     std::shared_ptr<comp::Offscreen> m_offscreen;
     std::shared_ptr<const comp::FrameTimer> m_frameTimer;
     std::function<void()> m_quitHandler;
-#if defined(SCIN_USE_CRASHPAD)
     std::shared_ptr<infra::CrashReporter> m_crashReporter;
-#endif
     std::array<std::unique_ptr<commands::Command>, commands::Command::Number::kCommandCount> m_commands;
 
     lo_server_thread m_tcpThread;

--- a/src/osc/commands/CreateCrashReport.cpp
+++ b/src/osc/commands/CreateCrashReport.cpp
@@ -14,12 +14,10 @@ CreateCrashReport::CreateCrashReport(osc::Dispatcher* dispatcher): Command(dispa
 CreateCrashReport::~CreateCrashReport() {}
 
 void CreateCrashReport::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
-#if __linux__ && defined(SCIN_USE_CRASHPAD)
+#if __linux__ || WIN32
     m_dispatcher->crashReporter()->dumpWithoutCrash();
 #else
-    spdlog::warn("crash report requested but build has crashpad disabled.");
-    int* foo = nullptr;
-    spdlog::error("deref null: {}", *foo);
+    spdlog::warn("crash report requested but crashpad doesn't support crashes on this platform.");
 #endif
 }
 

--- a/src/osc/commands/LogCrashReports.cpp
+++ b/src/osc/commands/LogCrashReports.cpp
@@ -14,12 +14,8 @@ LogCrashReports::LogCrashReports(osc::Dispatcher* dispatcher): Command(dispatche
 LogCrashReports::~LogCrashReports() {}
 
 void LogCrashReports::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
-#if defined(SCIN_USE_CRASHPAD)
     m_dispatcher->crashReporter()->logCrashReports();
     m_dispatcher->crashReporter()->closeDatabase();
-#else
-    spdlog::warn("crash log requested but build has crashpad disabled.");
-#endif
     m_dispatcher->respond(address, "/scin_done", "/scin_logCrashReports");
 }
 

--- a/src/osc/commands/UploadCrashReport.cpp
+++ b/src/osc/commands/UploadCrashReport.cpp
@@ -19,7 +19,6 @@ void UploadCrashReport::processMessage(int argc, lo_arg** argv, const char* type
         return;
     }
 
-#if defined(SCIN_USE_CRASHPAD)
     std::string uuid(reinterpret_cast<const char*>(argv[0]));
     if (uuid == "all") {
         m_dispatcher->crashReporter()->uploadAllCrashReports();
@@ -27,9 +26,6 @@ void UploadCrashReport::processMessage(int argc, lo_arg** argv, const char* type
         m_dispatcher->crashReporter()->uploadCrashReport(uuid);
     }
     m_dispatcher->crashReporter()->closeDatabase();
-#else
-    spdlog::warn("crash report upload requested but crash reports disabled in current build.");
-#endif
 
     m_dispatcher->respond(address, "/scin_done", "/scin_uploadCrashReport");
 }

--- a/tools/fetch-binary-deps.py
+++ b/tools/fetch-binary-deps.py
@@ -35,14 +35,12 @@ def main(argv):
     os.makedirs(binary_path, exist_ok=True)
     os.makedirs(install_ext, exist_ok=True)
 
-    needed_deps = ['ffmpeg-ext', 'vulkan-ext', 'swiftshader-ext']
+    needed_deps = ['crashpad-ext', 'ffmpeg-ext', 'vulkan-ext', 'swiftshader-ext']
 
     if platform.system() == 'Linux':
         os_name = 'linux'
-        needed_deps.append('crashpad-ext')
     elif platform.system() == 'Darwin':
         os_name = 'osx'
-        needed_deps.append('crashpad-ext')
     elif platform.system() == 'Windows':
         os_name = 'windows'
     else:

--- a/tools/prepare-symbol-dump.py
+++ b/tools/prepare-symbol-dump.py
@@ -38,6 +38,8 @@ def main(argv):
         dump_syms_command.append(argv[0])
     elif platform.system() == 'Darwin':
         dump_syms_command.append(argv[0])
+    elif platform.system() == 'Windows':
+        dump_syms_command.append(argv[0])
 
     dump_syms = subprocess.run(dump_syms_command, stdout=subprocess.PIPE)
     # syms is typically ~10MB of text data


### PR DESCRIPTION
## Purpose and motivation

Continuation of work in #136, adds crashpad integration to Windows.

## Implementation

Extensive work over in ScintillatorSynth\crashpad-ext to get the crashpad system to compile on Windows. Adds the libraries and handler from that project. Launches the handler on windows. Configures Travis to extract symbols on builds and upload them to GCS.

## Types of changes

* Behaviour change
* Enhancement

## Status

- [x] This PR is ready for review
