### PR TITLE
add missing symbol copy step on os x

### DIFF
--- a/.travis/before-deploy-osx.sh
+++ b/.travis/before-deploy-osx.sh
@@ -49,3 +49,7 @@ else
     shasum -a 256 -b scinsynth.app.zip > scinsynth.app.zip.sha256
     security delete-keychain build.keychain
 fi
+
+mkdir -p $HOME/symbols
+cp $TRAVIS_BUILD_DIR/build/symbols-scinsynth-*.gz $HOME/symbols
+


### PR DESCRIPTION
## Purpose and motivation

Adds in the missing copy step so the symbol deployment on MacOS will start working and hopefully fix the build.

## Implementation

Copies the built symbol file from the build directory to the staging area for deployment.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
