### PR TITLE
Fix Linux tag deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,9 @@ deploy:
 - provider: gcs
   access_key_id: "$GCS_SYMBOL_ID"
   secret_access_key: "$GCS_SYMBOL_KEY"
+  detect_encoding: true
   bucket: scintillator-gargamelle-symbols
-  cleanup: false
+  skip_cleanup: true
   local_dir: "$HOME/symbols"
   on:
     condition: "$DO_COVERAGE = false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
   access_key_id: "$AWS_KEY"
   secret_access_key: "$AWS_SECRET"
   bucket: scintillator-synth-coverage
+  region:  us-west-1
   local_dir: "$HOME/artifacts"
   upload_dir: artifacts/$TRAVIS_COMMIT
   edge: true
@@ -43,18 +44,21 @@ deploy:
   access_key_id: "$AWS_KEY"
   secret_access_key: "$AWS_SECRET"
   bucket: scintillator-synth-coverage
+  region:  us-west-1
   local_dir: "$HOME/builds"
   upload_dir: builds
   edge: true
   cleanup: false
   acl: public_read
   on:
+    tags: false
     condition: "$DO_COVERAGE = false"
     branch: master
 - provider: s3
   access_key_id: "$AWS_KEY"
   secret_access_key: "$AWS_SECRET"
   bucket: scintillator-synth-coverage
+  region:  us-west-1
   local_dir: "$HOME/releases"
   upload_dir: releases
   edge: true

--- a/.travis/before-deploy-linux.sh
+++ b/.travis/before-deploy-linux.sh
@@ -16,7 +16,7 @@ else
     mkdir -p $HOME/releases/$TRAVIS_TAG
     cp $TRAVIS_BUILD_DIR/bin/scinsynth-x86_64.AppImage $HOME/releases/$TRAVIS_TAG/.
     cd $HOME/releases/$TRAVIS_TAG
-    gzip scinsynth-x86_64.AppImage
+    gzip -f scinsynth-x86_64.AppImage
     shasum -a 256 -b scinsynth-x86_64.AppImage.gz > scinsynth-x86_64.AppImage.gz.sha256
 fi
 

--- a/.travis/before-deploy-windows.sh
+++ b/.travis/before-deploy-windows.sh
@@ -18,4 +18,5 @@ fi
 # symbol upload
 mkdir -p $HOME/symbols
 cp $TRAVIS_BUILD_DIR/build/symbols-scinsynth-*.gz $HOME/symbols
+ls -lah $HOME/symbols
 

--- a/.travis/before-install-windows.sh
+++ b/.travis/before-install-windows.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-choco install python3 gperf imagemagick.tool
+choco install python3 gperf imagemagick.tool gzip
 echo "*** installing pyyaml"
 cd $HOME
 git clone https://github.com/yaml/pyyaml.git pyyaml

--- a/.travis/script-windows.sh
+++ b/.travis/script-windows.sh
@@ -3,7 +3,7 @@
 cd $TRAVIS_BUILD_DIR/build
 cmake --build . --config RelWithDebInfo
 cmake --build . --config RelWithDebInfo --target dump_symbols
-ls -lah scinsynth-symbols-*.gz
+ls -lah symbols-scinsynth-*.gz
 cmake --install . --config RelWithDebInfo
 
 echo "Configuring host machine to use Swiftshader as a Vulkan device"

--- a/.travis/script-windows.sh
+++ b/.travis/script-windows.sh
@@ -3,6 +3,7 @@
 cd $TRAVIS_BUILD_DIR/build
 cmake --build . --config RelWithDebInfo
 cmake --build . --config RelWithDebInfo --target dump_symbols
+ls -lah scinsynth-symbols-*.gz
 cmake --install . --config RelWithDebInfo
 
 echo "Configuring host machine to use Swiftshader as a Vulkan device"

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -183,7 +183,7 @@ ScinServer {
 		Platform.case(
 			\osx, {
 				commandLine = scinBinaryPath.shellQuote + options.asOptionsString() + '--crashpadHandlerPath='
-				++ Scintillator.binDir +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "crashpad_handler";
+				++ (Scintillator.binDir +/+ "scinsynth.app" +/+ "Contents" +/+ "MacOS" +/+ "crashpad_handler").shellQuote;
 			},
 			\linux, {
 				commandLine = scinBinaryPath.shellQuote + options.asOptionsString();


### PR DESCRIPTION
## Purpose and motivation

The Travis linux build copies the file correctly to the release tag directory but was running both the tag deployment step as well as the regular build deployment step. But since the .travis/before-deploy-linux.sh script reacts to the environment variables it seems as though before-deploy was being run twice and the gzip step failed the second time due to an already-existing file. This PR disables running build uploads on tagged releases and hardens the gzip against successive invocations. It also adds some light diagnostics to the windows symbol upload which still seems to be wrong.

## Implementation

See above.

## Types of changes

* Bug fix
* Behaviour change

## Status

- [x] This PR is ready for review
