### PR TITLE
create avbuffers to be 32-byte aligned in width

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -666,7 +666,7 @@ add_custom_target(sclang_language_config
 )
 
 # Reference source and test images. We always use a specific git hash, to control which images we compare against.
-set(SCIN_TEST_IMAGE_HASH "86a51c4ddb2f6f036241ac021587d951ecd703f0")
+set(SCIN_TEST_IMAGE_HASH "afe8472fb6060f63271b8eca8ed731b0c53f9a29")
 ExternalProject_Add(reference_images
     PREFIX ref
     STEP_TARGETS update

--- a/src/av/Buffer.cpp
+++ b/src/av/Buffer.cpp
@@ -2,10 +2,11 @@
 
 namespace scin { namespace av {
 
-Buffer::Buffer(AVBufferRef* bufferRef, int width, int height):
+Buffer::Buffer(AVBufferRef* bufferRef, int width, int height, int stride):
     m_bufferRef(bufferRef),
     m_width(width),
-    m_height(height) {}
+    m_height(height),
+    m_stride(stride) {}
 
 Buffer::~Buffer() { av_buffer_unref(&m_bufferRef); }
 

--- a/src/av/Buffer.hpp
+++ b/src/av/Buffer.hpp
@@ -12,7 +12,7 @@ class Buffer {
 public:
     /*! Typically Buffers are allocated by BufferPool, which uses this constructor.
      */
-    Buffer(AVBufferRef* bufferRef, int width, int height);
+    Buffer(AVBufferRef* bufferRef, int width, int height, int stride);
     ~Buffer();
 
     AVBufferRef* addReference();
@@ -21,11 +21,13 @@ public:
     int size() { return m_bufferRef->size; }
     int width() const { return m_width; }
     int height() const { return m_height; }
+    int stride() const { return m_stride; }
 
 private:
     AVBufferRef* m_bufferRef;
     int m_width;
     int m_height;
+    int m_stride;
 };
 
 } // namespace av

--- a/src/av/BufferPool.cpp
+++ b/src/av/BufferPool.cpp
@@ -7,10 +7,17 @@
 namespace scin { namespace av {
 
 BufferPool::BufferPool(int width, int height): m_bufferPool(nullptr), m_width(width), m_height(height) {
-    m_bufferPool = av_buffer_pool_init(width * height * 4, nullptr);
+    // Assuming 4-byte-per-pixel image formats we byte-align to 32 bytes or 8 pixels all image widths.
+    m_stride = m_width;
+    if (m_width % 8) {
+        m_stride += (8 - (m_width % 8));
+    }
+
+    m_bufferPool = av_buffer_pool_init(m_stride * height * 4, nullptr);
     if (!m_bufferPool) {
         spdlog::error("failed to create BufferPool.");
     }
+
 }
 
 BufferPool::~BufferPool() { av_buffer_pool_uninit(&m_bufferPool); }
@@ -22,7 +29,7 @@ std::shared_ptr<Buffer> BufferPool::getBuffer() {
         return std::shared_ptr<Buffer>();
     }
 
-    return std::shared_ptr<Buffer>(new Buffer(bufferRef, m_width, m_height));
+    return std::shared_ptr<Buffer>(new Buffer(bufferRef, m_width, m_height, m_stride));
 }
 
 } // namespace av

--- a/src/av/BufferPool.cpp
+++ b/src/av/BufferPool.cpp
@@ -17,7 +17,6 @@ BufferPool::BufferPool(int width, int height): m_bufferPool(nullptr), m_width(wi
     if (!m_bufferPool) {
         spdlog::error("failed to create BufferPool.");
     }
-
 }
 
 BufferPool::~BufferPool() { av_buffer_pool_uninit(&m_bufferPool); }

--- a/src/av/BufferPool.hpp
+++ b/src/av/BufferPool.hpp
@@ -19,10 +19,17 @@ public:
 
     std::shared_ptr<Buffer> getBuffer();
 
+    /*! Some codecs have a pixel row alignment requirement for rows of pixels. BufferPool assumes all codecs will, and
+     * so may add to the width of each row to allow for that alignment. This byte pixel width is the stride and is
+     * accessed here.
+     */
+    int stride() const { return m_stride; }
+
 private:
     AVBufferPool* m_bufferPool;
     int m_width;
     int m_height;
+    int m_stride;
 };
 
 } // namespace av

--- a/src/av/Frame.cpp
+++ b/src/av/Frame.cpp
@@ -18,7 +18,7 @@ bool Frame::createFromBuffer(std::shared_ptr<Buffer> buffer) {
     }
     m_buffer = buffer;
     m_frame->data[0] = m_buffer->data();
-    m_frame->linesize[0] = m_buffer->width() * 4;
+    m_frame->linesize[0] = m_buffer->stride() * 4;
     m_frame->extended_data = m_frame->data;
     m_frame->width = m_buffer->width();
     m_frame->height = m_buffer->height();

--- a/src/comp/Offscreen.hpp
+++ b/src/comp/Offscreen.hpp
@@ -143,7 +143,6 @@ private:
     std::vector<std::shared_ptr<vk::CommandBuffer>> m_drawCommands;
     std::vector<std::vector<scin::av::Encoder::SendBuffer>> m_pendingEncodes;
     std::vector<std::shared_ptr<vk::HostImage>> m_readbackImages;
-    bool m_readbackSupportsBlit;
     // The index of this vector is the frameIndex, so the index of the pipelined framebuffer. The value is -1 if no
     // swapchain blit was requested, or the index of the swapchain source image (so 0 or 1).
     std::vector<int> m_pendingSwapchainBlits;

--- a/src/vulkan/Image.cpp
+++ b/src/vulkan/Image.cpp
@@ -125,9 +125,7 @@ HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device, VK_
 
 HostImage::~HostImage() {}
 
-bool HostImage::create(uint32_t width, uint32_t height) {
-    return createWithStride(width, height, width);
-}
+bool HostImage::create(uint32_t width, uint32_t height) { return createWithStride(width, height, width); }
 
 bool HostImage::createWithStride(uint32_t width, uint32_t height, uint32_t stride) {
     m_extent.width = width;

--- a/src/vulkan/Image.cpp
+++ b/src/vulkan/Image.cpp
@@ -121,19 +121,24 @@ FramebufferImage::~FramebufferImage() {}
 
 bool FramebufferImage::create(uint32_t width, uint32_t height) { return createDeviceImage(width, height, true); }
 
-HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device, VK_FORMAT_R8G8B8A8_UNORM) {}
+HostImage::HostImage(std::shared_ptr<Device> device): AllocatedImage(device, VK_FORMAT_R8G8B8A8_UNORM), m_stride(0) {}
 
 HostImage::~HostImage() {}
 
 bool HostImage::create(uint32_t width, uint32_t height) {
+    return createWithStride(width, height, width);
+}
+
+bool HostImage::createWithStride(uint32_t width, uint32_t height, uint32_t stride) {
     m_extent.width = width;
     m_extent.height = height;
+    m_stride = stride;
 
     VkImageCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     createInfo.imageType = VK_IMAGE_TYPE_2D;
     createInfo.format = m_format;
-    createInfo.extent.width = width;
+    createInfo.extent.width = stride;
     createInfo.extent.height = height;
     createInfo.extent.depth = 1;
     createInfo.arrayLayers = 1;

--- a/src/vulkan/Image.hpp
+++ b/src/vulkan/Image.hpp
@@ -111,10 +111,18 @@ public:
     HostImage& operator=(const HostImage&) = delete;
 
     bool create(uint32_t width, uint32_t height) override;
+    bool createWithStride(uint32_t width, uint32_t height, uint32_t stride);
 
     void* mappedAddress() { return m_info.pMappedData; }
 
+    /*! HostImages can support a larger width in memory than the width of the image, to account for image alignment
+     * requirements for some encoders. This value reflects the stride, which can be set by the createWithStride()
+     * function. If not specified it will be equal to the width of the buffer.
+     */
+    uint32_t stride() const { return m_stride; }
+
 protected:
+    uint32_t m_stride;
 };
 
 

--- a/tools/TestScripts/makeTestImages.scd
+++ b/tools/TestScripts/makeTestImages.scd
@@ -23,8 +23,9 @@ fork {
 	options.logLevel = 2;
 	options.createWindow = false;
 	options.frameRate = 0;
-	options.width = 400;
-	options.height = 400;
+	// Use prime numbers for image dimensions, to test any image alignment/padding assumptions.
+	options.width = 397;
+	options.height = 389;
 	options.swiftshader = true;
 	options.vulkanValidation = true;
 	options.onServerError = { |exitCode|


### PR DESCRIPTION
## Purpose and motivation

Fixes #143. FFMPEG, for some codecs, requires that the image data be 32-byte aligned along pixel rows. This allows images of arbitrary sizes to now be saved correctly, and updates the image integration tests to use prime numbers for image sizes in both dimensions, hopefully catching any future alignment errors that pop up.

## Implementation

Adds a `stride` member to Vulkan `HostBuffer` class as well as the wrapper `av::Buffer` class that represents that host-accessible memory area to the av subsystem. Computes `stride` to be 32-byte aligned. Update the test image reference version to account for the resized images.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
