### PR TITLE
implementation of cmd-period

### DIFF
--- a/HelpSource/Reference/Scintillator-Scinth-Server-Command-Reference.schelp
+++ b/HelpSource/Reference/Scintillator-Scinth-Server-Command-Reference.schelp
@@ -217,6 +217,20 @@ Sets the background color for the provided group.
 
 TODO
 
+subsection::/scin_g_freeAll
+
+Deletes all nodes in a group.
+
+table::
+## N * strong::int:: || group ID(s)
+::
+
+Frees all nodes in the group. A list of groups may be specified.
+
+note::
+Since only the default group is supported right now the group ID arguments are ignored.
+::
+
 section::ImageBuffer Commands
 
 The server leaves designation of unique image buffer numbers to the client. Allocation of an image buffer with a number already associated with another image buffer will result in the prior image buffer being deallocated.

--- a/classes/ScinServer.sc
+++ b/classes/ScinServer.sc
@@ -146,6 +146,8 @@ ScinServer {
 	}
 
 	init {
+		CmdPeriod.add(this);
+
 		if (options.isNil, {
 			options = ScinServerOptions.new;
 		});
@@ -165,6 +167,12 @@ ScinServer {
 		);
 
 		statusPoller = ScinServerStatusPoller.new(this);
+	}
+
+	cmdPeriod {
+		if (addr.notNil, {
+			addr.sendMsg('/scin_g_freeAll');
+		});
 	}
 
 	boot {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,6 +202,8 @@ set(scintillator_synth_files
     osc/commands/DumpOSC.hpp
     osc/commands/Echo.cpp
     osc/commands/Echo.hpp
+    osc/commands/GroupFreeAll.cpp
+    osc/commands/GroupFreeAll.hpp
     osc/commands/ImageBufferAllocRead.cpp
     osc/commands/ImageBufferAllocRead.hpp
     osc/commands/ImageBufferQuery.cpp

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -194,6 +194,13 @@ void Compositor::freeNodes(const std::vector<int>& nodeIDs) {
     }
 }
 
+void Compositor::groupFreeAll() {
+    std::lock_guard<std::mutex> lock(m_scinthMutex);
+    m_scinths.clear();
+    m_scinthMap.clear();
+    m_commandBufferDirty = true;
+}
+
 void Compositor::setRun(const std::vector<std::pair<int, int>>& pairs) {
     std::lock_guard<std::mutex> lock(m_scinthMutex);
     for (const auto& pair : pairs) {

--- a/src/comp/Compositor.hpp
+++ b/src/comp/Compositor.hpp
@@ -86,6 +86,10 @@ public:
      */
     void freeNodes(const std::vector<int>& nodeIDs);
 
+    /*! Free all nodes within the default group.
+     */
+    void groupFreeAll();
+
     /*! Sets the pause/play status of provided nodeID in the provided list of pairs.
      *
      * \param pairs A pair of integers, with the first element as a nodeID and the second as a run value. A value of

--- a/src/osc/Dispatcher.cpp
+++ b/src/osc/Dispatcher.cpp
@@ -19,6 +19,7 @@
 #include "osc/commands/DefReceive.hpp"
 #include "osc/commands/DumpOSC.hpp"
 #include "osc/commands/Echo.hpp"
+#include "osc/commands/GroupFreeAll.hpp"
 #include "osc/commands/ImageBufferAllocRead.hpp"
 #include "osc/commands/ImageBufferQuery.hpp"
 #include "osc/commands/LogAppend.hpp"
@@ -102,6 +103,7 @@ bool Dispatcher::create(const std::string& bindPort, bool dumpOSC) {
     m_commands[commands::Command::kNRun].reset(new commands::NodeRun(this));
     m_commands[commands::Command::kNSet].reset(new commands::NodeSet(this));
     m_commands[commands::Command::kSNew].reset(new commands::ScinthNew(this));
+    m_commands[commands::Command::kGroupFreeAll].reset(new commands::GroupFreeAll(this));
     m_commands[commands::Command::kIBAllocRead].reset(new commands::ImageBufferAllocRead(this));
     m_commands[commands::Command::kIBQuery].reset(new commands::ImageBufferQuery(this));
     m_commands[commands::Command::kNRTScreenShot].reset(new commands::ScreenShot(this));

--- a/src/osc/commands/Command.cpp.in
+++ b/src/osc/commands/Command.cpp.in
@@ -31,6 +31,7 @@ n_free,             scin::osc::commands::Command::Number::kNFree
 n_run,              scin::osc::commands::Command::Number::kNRun
 n_set,              scin::osc::commands::Command::Number::kNSet
 s_new,              scin::osc::commands::Command::Number::kSNew
+g_freeAll,          scin::osc::commands::Command::Number::kGroupFreeAll
 ib_allocRead,       scin::osc::commands::Command::Number::kIBAllocRead
 ib_query,           scin::osc::commands::Command::Number::kIBQuery
 nrt_screenShot,     scin::osc::commands::Command::Number::kNRTScreenShot

--- a/src/osc/commands/Command.hpp
+++ b/src/osc/commands/Command.hpp
@@ -38,6 +38,9 @@ public:
         // Scinth Commands
         kSNew = 9,
 
+        // Group Commands
+        kGroupFreeAll = 24,
+
         // ImageBuffer Commands
         kIBAllocRead = 29,
         kIBQuery = 47,

--- a/src/osc/commands/GroupFreeAll.cpp
+++ b/src/osc/commands/GroupFreeAll.cpp
@@ -1,0 +1,22 @@
+#include "osc/commands/GroupFreeAll.hpp"
+
+#include "comp/Compositor.hpp"
+#include "osc/Dispatcher.hpp"
+
+#include "spdlog/spdlog.h"
+
+#include <vector>
+
+namespace scin { namespace osc { namespace commands {
+
+GroupFreeAll::GroupFreeAll(osc::Dispatcher* dispatcher): Command(dispatcher) {}
+
+GroupFreeAll::~GroupFreeAll() {}
+
+void GroupFreeAll::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+    m_dispatcher->compositor()->groupFreeAll();
+}
+
+} // namespace commands
+} // namespace osc
+} // namespace scin

--- a/src/osc/commands/GroupFreeAll.hpp
+++ b/src/osc/commands/GroupFreeAll.hpp
@@ -1,0 +1,20 @@
+#ifndef SRC_OSC_COMMANDS_GROUP_FREE_ALL_HPP_
+#define SRC_OSC_COMMANDS_GROUP_FREE_ALL_HPP_
+
+#include "osc/commands/Command.hpp"
+
+namespace scin { namespace osc { namespace commands {
+
+class GroupFreeAll : public Command {
+public:
+    GroupFreeAll(osc::Dispatcher* dispatcher);
+    virtual ~GroupFreeAll();
+
+    void processMessage(int argc, lo_arg** argv, const char* types, lo_address address) override;
+};
+
+} // namespace commands
+} // namespace osc
+} // namespace scin
+
+#endif // SRC_OSC_COMMANDS_GROUP_FREE_ALL_HPP_


### PR DESCRIPTION
## Purpose and motivation

Fixes #130. Adds support for automatically freeing all running Scinths in the default group when cmd+period is pressed in the sclang IDE.

## Implementation

Adds a new OSC command `scin_g_freeAll` which will eventually take a list of group IDs to free the nodes from but at the moment there's only the default group so the arguments are ignored.

## Types of changes

* Enhancement

## Status

- [x] This PR is ready for review
