### PR TITLE
Turn on all warnings, and treat warnings as compilation errors

### DIFF
--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -56,5 +56,13 @@ else
     echo "/usr/local/ssl/lib" > $TRAVIS_HOME/openssl-1.1.1g.conf || exit 2
     sudo mv $TRAVIS_HOME/openssl-1.1.1g.conf /etc/ld.so.conf.d/. || exit 3
     sudo ldconfig -v || exit 4
+
+    cd $TRAVIS_HOME
+    wget http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz
+    tar xzf gperf-3.1.tar.gz
+    cd gperf-3.1
+    ./configure --prefix=/usr/local/bin
+    make
+    sudo make install
 fi
 

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -61,7 +61,7 @@ else
     wget http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz
     tar xzf gperf-3.1.tar.gz
     cd gperf-3.1
-    ./configure --prefix=/usr/local/bin
+    ./configure --prefix=/usr/local
     make
     sudo make install
 fi

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -4,7 +4,7 @@ export HOMEBREW_NO_ANALYTICS=1
 
 brew update
 brew unlink python@2
-brew install ccache doxygen shtool imagemagick
+brew install ccache doxygen shtool imagemagick gperf
 python3 -m pip install pyyaml
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache

--- a/.travis/before-script-linux.sh
+++ b/.travis/before-script-linux.sh
@@ -7,7 +7,11 @@ if [ $DO_COVERAGE = true ]; then
     cmake -DSCIN_BUILD_DOCS=ON -DCMAKE_BUILD_TYPE=Coverage -DLLVM_COV="llvm-cov-8" -DLLVM_PROFDATA="llvm-profdata-8"   \
         -DPYTHON_EXECUTABLE=`which python3` -DSCIN_SCLANG=`which sclang` ..
 else
-    cmake -DSCIN_BUILD_DOCS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPYTHON_EXECUTABLE=`which python3`                  \
-        -DSCIN_SCLANG=`which sclang` ..
+    PATH=/usr/local/bin:$PATH cmake                                                                                    \
+        -DSCIN_BUILD_DOCS=OFF                                                                                          \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo                                                                              \
+        -DPYTHON_EXECUTABLE=`which python3`                                                                            \
+        -DSCIN_SCLANG=`which sclang`                                                                                   \
+        ..
 fi
 

--- a/Building-Scintillator.md
+++ b/Building-Scintillator.md
@@ -17,5 +17,10 @@ cd build
 cmake ..
 make
 
-If on Xenial Linux you're going to need to build your own SSL from sources, or consider re-using the one built inside of
-install-ext
+
+Xenial
+------
+
+Requires gperf 3.1, which will need to be built from sources.
+Requires openssl 1.1, which will need to be built from sources, or copied from the install-ext/ssl directory.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,13 @@ add_library(scintillator_base STATIC
     base/VGen.hpp
 )
 
+target_compile_options(scintillator_base PRIVATE
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+     -Wall -Werror>
+     $<$<CXX_COMPILER_ID:MSVC>:
+     /W4 /WX>
+)
+
 target_link_libraries(scintillator_base
     fmt
     glm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(scintillator_base STATIC
 
 target_compile_options(scintillator_base PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-     -Wall -Wextra -Werror>
+     -Wall -Wextra -Wpedantic -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
      /W4 /WX>
 )
@@ -91,7 +91,7 @@ add_executable(run_unittests
 
 target_compile_options(run_unittests PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-     -Wall -Wextra -Werror>
+     -Wall -Wextra -Wpedantic -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
      /W4 /WX>
 )
@@ -246,6 +246,7 @@ set(scintillator_synth_files
     osc/commands/Sync.hpp
     osc/commands/UploadCrashReport.cpp
     osc/commands/UploadCrashReport.hpp
+    osc/LOIncludes.hpp
 
     vulkan/Buffer.cpp
     vulkan/Buffer.hpp
@@ -305,7 +306,7 @@ endif()
 
 target_compile_options(scinsynth PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-     -Wall -Wextra -Werror>
+     -Wall -Wextra -Wpedantic -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
      /W4 /WX>
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ target_compile_options(scintillator_base PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
      -Wall -Wextra -Wpedantic -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
-     /W4 /WX>
+     /W4 /WX /DNOMINMAX>
 )
 
 target_link_libraries(scintillator_base
@@ -94,7 +94,7 @@ target_compile_options(run_unittests PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
      -Wall -Wextra -Wpedantic -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
-     /W4 /WX>
+     /W4 /WX /DNOMINMAX>
 )
 
 target_link_libraries(run_unittests
@@ -309,7 +309,7 @@ target_compile_options(scinsynth PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
      -Wall -Wextra -Wpedantic -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
-     /W4 /WX>
+     /W4 /WX /DNOMINMAX>
 )
 
 # Force using the locally sourced libraries as opposed to system libs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(run_unittests
     base/AbstractScinthDef_unittests.cpp
     base/AbstractVGen_unittests.cpp
     base/Archetypes_unittests.cpp
+    base/GTestIncludes.hpp
     base/Manifest_unittests.cpp
     base/Shape_unittests.cpp
     base/VGen_unittests.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(scintillator_base STATIC
 
 target_compile_options(scintillator_base PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-     -Wall -Werror>
+     -Wall -Wextra -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
      /W4 /WX>
 )
@@ -91,7 +91,7 @@ add_executable(run_unittests
 
 target_compile_options(run_unittests PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-     -Wall -Werror>
+     -Wall -Wextra -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
      /W4 /WX>
 )
@@ -305,7 +305,7 @@ endif()
 
 target_compile_options(scinsynth PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-     -Wall -Werror>
+     -Wall -Wextra -Werror>
      $<$<CXX_COMPILER_ID:MSVC>:
      /W4 /WX>
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,13 @@ add_executable(run_unittests
     run_unittests.cpp
 )
 
+target_compile_options(run_unittests PRIVATE
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+     -Wall -Werror>
+     $<$<CXX_COMPILER_ID:MSVC>:
+     /W4 /WX>
+)
+
 target_link_libraries(run_unittests
     gflags
     glm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,6 +303,13 @@ elseif(WIN32)
     )
 endif()
 
+target_compile_options(scinsynth PRIVATE
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+     -Wall -Werror>
+     $<$<CXX_COMPILER_ID:MSVC>:
+     /W4 /WX>
+)
+
 # Force using the locally sourced libraries as opposed to system libs
 find_library(SHADERC_LIBRARY
     NAMES shaderc_combined

--- a/src/audio/Ingress.cpp
+++ b/src/audio/Ingress.cpp
@@ -7,7 +7,7 @@ namespace scin { namespace audio {
 
 const int kSamplesPerChannel = 8192;
 
-Ingress::Ingress(int channels, int sampleRate):
+Ingress::Ingress(int channels, double sampleRate):
     m_channels(channels),
     m_sampleRate(sampleRate),
     m_ringBuffer(new PaUtilRingBuffer),

--- a/src/audio/Ingress.cpp
+++ b/src/audio/Ingress.cpp
@@ -34,7 +34,7 @@ void Ingress::ingestSamples(const float* input, unsigned long frameCount) {
         // Clobber oldest elements if needed.
         dropSamples(elementCount - writeAvailable);
     }
-    unsigned long framesWritten = PaUtil_WriteRingBuffer(m_ringBuffer.get(), input, elementCount);
+    PaUtil_WriteRingBuffer(m_ringBuffer.get(), input, elementCount);
 }
 
 unsigned long Ingress::availableFrames() { return PaUtil_GetRingBufferReadAvailable(m_ringBuffer.get()) / m_channels; }

--- a/src/audio/Ingress.hpp
+++ b/src/audio/Ingress.hpp
@@ -12,7 +12,7 @@ namespace scin { namespace audio {
 // system when there's new data available and what that data might be.
 class Ingress {
 public:
-    Ingress(int channels, int sampleRate);
+    Ingress(int channels, double sampleRate);
     ~Ingress();
 
     bool create();
@@ -31,11 +31,11 @@ public:
     unsigned long extractSamples(float* output, unsigned long frameCount);
 
     int channels() const { return m_channels; }
-    int sampleRate() const { return m_sampleRate; }
+    double sampleRate() const { return m_sampleRate; }
 
 private:
     int m_channels;
-    int m_sampleRate;
+    double m_sampleRate;
 
     std::unique_ptr<PaUtilRingBuffer> m_ringBuffer;
     std::unique_ptr<float[]> m_buffer;

--- a/src/audio/PortAudio.cpp
+++ b/src/audio/PortAudio.cpp
@@ -11,8 +11,9 @@
 #endif
 
 namespace {
-int portAudioCallback(const void* input, void* output, unsigned long frameCount,
-                      const PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags, void* userData) {
+int portAudioCallback(const void* input, void* /* output */, unsigned long frameCount,
+                      const PaStreamCallbackTimeInfo* /* timeInfo */, PaStreamCallbackFlags /* statusFlags */,
+                      void* userData) {
     scin::audio::PortAudio* audio = static_cast<scin::audio::PortAudio*>(userData);
     if (input && audio->inputChannels()) {
         audio->ingress()->ingestSamples(static_cast<const float*>(input), frameCount);

--- a/src/av/AVIncludes.hpp
+++ b/src/av/AVIncludes.hpp
@@ -1,10 +1,19 @@
 #ifndef SRC_AV_AV_INCLUDES_HPP_
 #define SRC_AV_AV_INCLUDES_HPP_
 
+#if _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4244)
+#endif
+
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
 }
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // SRC_AV_INCLUDES_HPP_

--- a/src/av/AVIncludes.hpp
+++ b/src/av/AVIncludes.hpp
@@ -2,8 +2,8 @@
 #define SRC_AV_AV_INCLUDES_HPP_
 
 #if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4244)
+#    pragma warning(push)
+#    pragma warning(disable : 4244)
 #endif
 
 extern "C" {
@@ -13,7 +13,7 @@ extern "C" {
 }
 
 #if _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #endif
 
 #endif // SRC_AV_INCLUDES_HPP_

--- a/src/base/AbstractSampler_unittests.cpp
+++ b/src/base/AbstractSampler_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/AbstractSampler.hpp"
 

--- a/src/base/AbstractScinthDef.cpp
+++ b/src/base/AbstractScinthDef.cpp
@@ -45,14 +45,14 @@ bool AbstractScinthDef::build() {
     if (!buildComputeStage(computeVGens)) {
         return false;
     }
-    if (!finalizeShaders(computeVGens, vertexVGens, fragmentVGens)) {
+    if (!finalizeShaders()) {
         return false;
     }
 
     return true;
 }
 
-bool AbstractScinthDef::groupVGens(int index, AbstractVGen::Rates maxRate, std::set<size_t>& computeVGens,
+bool AbstractScinthDef::groupVGens(size_t index, AbstractVGen::Rates maxRate, std::set<size_t>& computeVGens,
                                    std::set<size_t>& vertexVGens, std::set<size_t>& fragmentVGens) {
     AbstractVGen::Rates vgenRate = m_instances[index].rate();
 
@@ -492,8 +492,7 @@ bool AbstractScinthDef::buildComputeStage(const std::set<size_t>& computeVGens) 
     return true;
 }
 
-bool AbstractScinthDef::finalizeShaders(const std::set<size_t>& computeVGens, const std::set<size_t>& vertexVGens,
-                                        const std::set<size_t>& fragmentVGens) {
+bool AbstractScinthDef::finalizeShaders() {
     // Pack all the manifests as we have analyzed all VGens so they should all be final now.
     m_fragmentManifest.pack();
     m_uniformManifest.pack();
@@ -786,12 +785,13 @@ bool AbstractScinthDef::finalizeShaders(const std::set<size_t>& computeVGens, co
     return true;
 }
 
-int AbstractScinthDef::indexForParameterName(const std::string& name) const {
+bool AbstractScinthDef::indexForParameterName(const std::string& name, size_t& indexOut) const {
     auto it = m_parameterIndices.find(name);
     if (it == m_parameterIndices.end()) {
-        return -1;
+        return false;
     }
-    return it->second;
+    indexOut = it->second;
+    return true;
 }
 
 } // namespace base

--- a/src/base/AbstractScinthDef.cpp
+++ b/src/base/AbstractScinthDef.cpp
@@ -29,13 +29,13 @@ bool AbstractScinthDef::build() {
     m_fragmentOutputName = m_prefix + "_outColor";
 
     // Pre-process parameter indices map, for quick lookup of parameter index by name.
-    for (auto i = 0; i < m_parameters.size(); ++i) {
+    for (size_t i = 0; i < m_parameters.size(); ++i) {
         m_parameterIndices[m_parameters[i].name()] = i;
     }
 
-    std::set<int> computeVGens;
-    std::set<int> vertexVGens;
-    std::set<int> fragmentVGens;
+    std::set<size_t> computeVGens;
+    std::set<size_t> vertexVGens;
+    std::set<size_t> fragmentVGens;
     if (!groupVGens(m_instances.size() - 1, AbstractVGen::Rates::kPixel, computeVGens, vertexVGens, fragmentVGens)) {
         return false;
     }
@@ -52,8 +52,8 @@ bool AbstractScinthDef::build() {
     return true;
 }
 
-bool AbstractScinthDef::groupVGens(int index, AbstractVGen::Rates maxRate, std::set<int>& computeVGens,
-                                   std::set<int>& vertexVGens, std::set<int>& fragmentVGens) {
+bool AbstractScinthDef::groupVGens(int index, AbstractVGen::Rates maxRate, std::set<size_t>& computeVGens,
+                                   std::set<size_t>& vertexVGens, std::set<size_t>& fragmentVGens) {
     AbstractVGen::Rates vgenRate = m_instances[index].rate();
 
     // Bucket VGen index and validate rate is supported value.
@@ -108,9 +108,9 @@ bool AbstractScinthDef::groupVGens(int index, AbstractVGen::Rates maxRate, std::
     }
 
     // Recurse up the graph, propagating any errors encountered.
-    for (auto i = 0; i < m_instances[index].numberOfInputs(); ++i) {
+    for (size_t i = 0; i < m_instances[index].numberOfInputs(); ++i) {
         if (m_instances[index].getInputType(i) == VGen::InputType::kVGen) {
-            int vgenIndex, vgenOutput;
+            size_t vgenIndex, vgenOutput;
             m_instances[index].getInputVGenIndex(i, vgenIndex, vgenOutput);
             if (!groupVGens(vgenIndex, vgenRate, computeVGens, vertexVGens, fragmentVGens)) {
                 return false;
@@ -121,12 +121,12 @@ bool AbstractScinthDef::groupVGens(int index, AbstractVGen::Rates maxRate, std::
     return true;
 }
 
-bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const std::set<int>& fragmentVGens) {
+bool AbstractScinthDef::buildDrawStage(const std::set<size_t>& vertexVGens, const std::set<size_t>& fragmentVGens) {
     m_fragmentShader = "";
     for (auto index : fragmentVGens) {
         // Build input names (for parameterization) and add to relevant manifests as needed.
         std::vector<std::string> inputs;
-        for (auto j = 0; j < m_instances[index].numberOfInputs(); ++j) {
+        for (size_t j = 0; j < m_instances[index].numberOfInputs(); ++j) {
             VGen::InputType type = m_instances[index].getInputType(j);
             switch (type) {
                 // TODO: support for higher-dimensional constants? VGen has it, but we drop it here.
@@ -138,13 +138,13 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
             } break;
 
             case VGen::InputType::kParameter: {
-                int parameterIndex;
+                size_t parameterIndex;
                 m_instances[index].getInputParameterIndex(j, parameterIndex);
                 inputs.emplace_back(fmt::format("{}_parameters.{}", m_prefix, m_parameters[parameterIndex].name()));
             } break;
 
             case VGen::InputType::kVGen: {
-                int vgenIndex, vgenOutput;
+                size_t vgenIndex, vgenOutput;
                 m_instances[index].getInputVGenIndex(j, vgenIndex, vgenOutput);
                 switch (m_instances[vgenIndex].rate()) {
                 case AbstractVGen::Rates::kPixel:
@@ -204,6 +204,10 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
                 intrinsics[Intrinsic::kPi] = "3.1415926535897932384626433832795f";
                 break;
 
+            case kPosition:
+                spdlog::error("Vertex position intrinsics not currently supported in fragment-rate VGens");
+                return false;
+
             case kSampler: {
                 if (m_instances[index].imageArgType() == VGen::InputType::kConstant) {
                     intrinsics[Intrinsic::kSampler] =
@@ -231,8 +235,8 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
         }
 
         std::vector<std::string> outputs;
-        std::vector<int> outputDimensions;
-        for (auto j = 0; j < m_instances[index].numberOfOutputs(); ++j) {
+        std::vector<size_t> outputDimensions;
+        for (size_t j = 0; j < m_instances[index].numberOfOutputs(); ++j) {
             if (index < m_instances.size() - 1 || j > 0) {
                 outputs.emplace_back(fmt::format("{}_out_{}_{}", m_prefix, index, j));
             } else {
@@ -256,7 +260,7 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
 
     for (auto index : vertexVGens) {
         std::vector<std::string> inputs;
-        for (auto j = 0; j < m_instances[index].numberOfInputs(); ++j) {
+        for (size_t j = 0; j < m_instances[index].numberOfInputs(); ++j) {
             VGen::InputType type = m_instances[index].getInputType(j);
             switch (type) {
             // same as fragment-rate
@@ -268,13 +272,13 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
 
             // same as fragment rate
             case VGen::InputType::kParameter: {
-                int parameterIndex;
+                size_t parameterIndex;
                 m_instances[index].getInputParameterIndex(j, parameterIndex);
                 inputs.emplace_back(fmt::format("{}_parameters.{}", m_prefix, m_parameters[parameterIndex].name()));
             } break;
 
             case VGen::InputType::kVGen: {
-                int vgenIndex, vgenOutput;
+                size_t vgenIndex, vgenOutput;
                 m_instances[index].getInputVGenIndex(j, vgenIndex, vgenOutput);
                 switch (m_instances[vgenIndex].rate()) {
                 case AbstractVGen::Rates::kPixel:
@@ -328,6 +332,10 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
                 intrinsics[Intrinsic::kPi] = "3.1415926535897932384626433832795f";
                 break;
 
+            case kPosition:
+                intrinsics[Intrinsic::kPosition] = "gl_Position";
+                break;
+
             // same as fragment rate
             case kSampler:
                 if (m_instances[index].imageArgType() == VGen::InputType::kConstant) {
@@ -355,8 +363,8 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
         }
 
         std::vector<std::string> outputs;
-        std::vector<int> outputDimensions;
-        for (auto j = 0; j < m_instances[index].numberOfOutputs(); ++j) {
+        std::vector<size_t> outputDimensions;
+        for (size_t j = 0; j < m_instances[index].numberOfOutputs(); ++j) {
             outputs.emplace_back(fmt::format("{}_out_{}_{}", m_prefix, index, j));
             outputDimensions.push_back(m_instances[index].outputDimension(j));
         }
@@ -372,7 +380,7 @@ bool AbstractScinthDef::buildDrawStage(const std::set<int>& vertexVGens, const s
     return true;
 }
 
-bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
+bool AbstractScinthDef::buildComputeStage(const std::set<size_t>& computeVGens) {
     // It's possible we have no frame-rate VGens, in which case we can elide the compute stage entirely.
     m_hasComputeStage = computeVGens.size() > 0;
     if (!m_hasComputeStage) {
@@ -381,7 +389,7 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
 
     for (auto index : computeVGens) {
         std::vector<std::string> inputs;
-        for (auto j = 0; j < m_instances[index].numberOfInputs(); ++j) {
+        for (size_t j = 0; j < m_instances[index].numberOfInputs(); ++j) {
             VGen::InputType type = m_instances[index].getInputType(j);
             switch (type) {
             // same as fragment
@@ -393,13 +401,13 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
 
             // same as fragment
             case VGen::InputType::kParameter: {
-                int parameterIndex;
+                size_t parameterIndex;
                 m_instances[index].getInputParameterIndex(j, parameterIndex);
                 inputs.emplace_back(fmt::format("{}_parameters.{}", m_prefix, m_parameters[parameterIndex].name()));
             } break;
 
             case VGen::InputType::kVGen: {
-                int vgenIndex, vgenOutput;
+                size_t vgenIndex, vgenOutput;
                 m_instances[index].getInputVGenIndex(j, vgenIndex, vgenOutput);
                 switch (m_instances[vgenIndex].rate()) {
                 case AbstractVGen::Rates::kPixel:
@@ -459,6 +467,7 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
             case kFragCoord:
             case kTexPos:
             case kNormPos:
+            case kPosition:
                 spdlog::error("ScinthDef Unsupported intrinsics in frame-rate VGen index {}.");
                 break;
             }
@@ -466,8 +475,8 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
 
         // same as fragment
         std::vector<std::string> outputs;
-        std::vector<int> outputDimensions;
-        for (auto j = 0; j < m_instances[index].numberOfOutputs(); ++j) {
+        std::vector<size_t> outputDimensions;
+        for (size_t j = 0; j < m_instances[index].numberOfOutputs(); ++j) {
             outputs.emplace_back(fmt::format("{}_out_{}_{}", m_prefix, index, j));
             outputDimensions.push_back(m_instances[index].outputDimension(j));
         }
@@ -483,8 +492,8 @@ bool AbstractScinthDef::buildComputeStage(const std::set<int>& computeVGens) {
     return true;
 }
 
-bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const std::set<int>& vertexVGens,
-                                        const std::set<int>& fragmentVGens) {
+bool AbstractScinthDef::finalizeShaders(const std::set<size_t>& computeVGens, const std::set<size_t>& vertexVGens,
+                                        const std::set<size_t>& fragmentVGens) {
     // Pack all the manifests as we have analyzed all VGens so they should all be final now.
     m_fragmentManifest.pack();
     m_uniformManifest.pack();
@@ -498,7 +507,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
 
     vertexHeader += "\n// --- vertex shader inputs from vertex format\n";
     // Describe all inputs to the vertex shader via vertex data.
-    for (auto i = 0; i < m_vertexManifest.numberOfElements(); ++i) {
+    for (size_t i = 0; i < m_vertexManifest.numberOfElements(); ++i) {
         // NOTE: hard-coded assumption that all inputs take 1 slot likely won't work for matrices
         vertexHeader +=
             fmt::format("layout(location = {}) in {} {}_in_{};\n", i, m_vertexManifest.typeNameForElement(i), m_prefix,
@@ -510,7 +519,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
         // outputs and pass-through intrinsics, as inputs to the fragment shader.
         vertexHeader += "\n// -- vertex shader outputs to fragment shader\n";
         fragmentHeader += "\n// --- fragment shader inputs from vertex shader\n";
-        for (auto i = 0; i < m_fragmentManifest.numberOfElements(); ++i) {
+        for (size_t i = 0; i < m_fragmentManifest.numberOfElements(); ++i) {
             if (m_fragmentManifest.intrinsicForElement(i) != Intrinsic::kPosition) {
                 fragmentHeader +=
                     fmt::format("layout(location = {}) in {} {}_in_{};\n", i, m_fragmentManifest.typeNameForElement(i),
@@ -550,7 +559,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
     int binding = 0;
     if (m_uniformManifest.numberOfElements()) {
         std::string uboBody;
-        for (auto i = 0; i < m_uniformManifest.numberOfElements(); ++i) {
+        for (size_t i = 0; i < m_uniformManifest.numberOfElements(); ++i) {
             uboBody += fmt::format("    {} {};\n", m_uniformManifest.typeNameForElement(i),
                                    m_uniformManifest.nameForElement(i));
         }
@@ -602,7 +611,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
 
     if (m_computeManifest.numberOfElements()) {
         std::string bufferBody;
-        for (auto i = 0; i < m_computeManifest.numberOfElements(); ++i) {
+        for (size_t i = 0; i < m_computeManifest.numberOfElements(); ++i) {
             bufferBody += fmt::format("    {} {};\n", m_computeManifest.typeNameForElement(i),
                                       m_computeManifest.nameForElement(i));
         }
@@ -688,7 +697,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
         binding = 0;
         if (m_uniformManifest.numberOfElements()) {
             std::string uboBody;
-            for (auto i = 0; i < m_uniformManifest.numberOfElements(); ++i) {
+            for (size_t i = 0; i < m_uniformManifest.numberOfElements(); ++i) {
                 uboBody += fmt::format("    {} {};\n", m_uniformManifest.typeNameForElement(i),
                                        m_uniformManifest.nameForElement(i));
 
@@ -735,7 +744,7 @@ bool AbstractScinthDef::finalizeShaders(const std::set<int>& computeVGens, const
 
         // Compute shader outputs in an output buffer, add copy instructions at the same time.
         std::string bufferBody;
-        for (auto i = 0; i < m_computeManifest.numberOfElements(); ++i) {
+        for (size_t i = 0; i < m_computeManifest.numberOfElements(); ++i) {
             bufferBody += fmt::format("    {} {};\n", m_computeManifest.typeNameForElement(i),
                                       m_computeManifest.nameForElement(i));
             m_computeShader += fmt::format("\n    // -- export compute VGen output to uniform buffer"

--- a/src/base/AbstractScinthDef.cpp
+++ b/src/base/AbstractScinthDef.cpp
@@ -83,10 +83,6 @@ bool AbstractScinthDef::groupVGens(size_t index, AbstractVGen::Rates maxRate, st
 
     // Extract image parameters if this is a sampling VGen.
     if (m_instances[index].abstractVGen()->isSampler()) {
-        if (m_instances[index].imageIndex() < 0) {
-            spdlog::error("AbstractScinthDef {} has VGen {} with bad image index.", m_name, index);
-            return false;
-        }
         if (m_instances[index].imageArgType() == VGen::InputType::kConstant) {
             if (vgenRate == AbstractVGen::Rates::kFrame) {
                 m_computeFixedImages.insert({ m_instances[index].sampler().key(), m_instances[index].imageIndex() });

--- a/src/base/AbstractScinthDef.hpp
+++ b/src/base/AbstractScinthDef.hpp
@@ -79,13 +79,13 @@ public:
     const std::vector<VGen>& instances() const { return m_instances; }
 
     // First element in pair is sampler key, second element is the imageID.
-    const std::set<std::pair<uint32_t, int>>& computeFixedImages() const { return m_computeFixedImages; }
-    const std::set<std::pair<uint32_t, int>>& drawFixedImages() const { return m_drawFixedImages; }
+    const std::set<std::pair<uint32_t, size_t>>& computeFixedImages() const { return m_computeFixedImages; }
+    const std::set<std::pair<uint32_t, size_t>>& drawFixedImages() const { return m_drawFixedImages; }
     // First element in pair is sampler key, second is parameter index.
-    const std::set<std::pair<uint32_t, int>>& computeParameterizedImages() const {
+    const std::set<std::pair<uint32_t, size_t>>& computeParameterizedImages() const {
         return m_computeParameterizedImages;
     }
-    const std::set<std::pair<uint32_t, int>>& drawParameterizedImages() const { return m_drawParameterizedImages; }
+    const std::set<std::pair<uint32_t, size_t>>& drawParameterizedImages() const { return m_drawParameterizedImages; }
 
     bool hasComputeStage() const { return m_hasComputeStage; }
 
@@ -127,10 +127,10 @@ private:
     std::vector<VGen> m_instances;
 
     // These are pairs of sampler config, image or parameter index, grouped into sets to de-dupe the pairs.
-    std::set<std::pair<uint32_t, int>> m_computeFixedImages;
-    std::set<std::pair<uint32_t, int>> m_computeParameterizedImages;
-    std::set<std::pair<uint32_t, int>> m_drawFixedImages;
-    std::set<std::pair<uint32_t, int>> m_drawParameterizedImages;
+    std::set<std::pair<uint32_t, size_t>> m_computeFixedImages;
+    std::set<std::pair<uint32_t, size_t>> m_computeParameterizedImages;
+    std::set<std::pair<uint32_t, size_t>> m_drawFixedImages;
+    std::set<std::pair<uint32_t, size_t>> m_drawParameterizedImages;
 
     // To avoid collision with any VGen code we attach a ScinthDef name and random number prefix to most global names.
     std::string m_prefix;

--- a/src/base/AbstractScinthDef.hpp
+++ b/src/base/AbstractScinthDef.hpp
@@ -112,13 +112,13 @@ private:
      *        graph.
      * \return true if successful, false on error.
      */
-    bool groupVGens(int index, AbstractVGen::Rates rate, std::set<int>& computeVGens, std::set<int>& vertexVGens,
-                    std::set<int>& fragmentVGens);
+    bool groupVGens(int index, AbstractVGen::Rates rate, std::set<size_t>& computeVGens, std::set<size_t>& vertexVGens,
+                    std::set<size_t>& fragmentVGens);
 
-    bool buildComputeStage(const std::set<int>& computeVGens);
-    bool buildDrawStage(const std::set<int>& vertexVGens, const std::set<int>& fragmentVGens);
-    bool finalizeShaders(const std::set<int>& computeVGens, const std::set<int>& vertexVGens,
-                         const std::set<int>& fragmentVGens);
+    bool buildComputeStage(const std::set<size_t>& computeVGens);
+    bool buildDrawStage(const std::set<size_t>& vertexVGens, const std::set<size_t>& fragmentVGens);
+    bool finalizeShaders(const std::set<size_t>& computeVGens, const std::set<size_t>& vertexVGens,
+                         const std::set<size_t>& fragmentVGens);
 
     std::string m_name;
     std::unique_ptr<Shape> m_shape;

--- a/src/base/AbstractScinthDef.hpp
+++ b/src/base/AbstractScinthDef.hpp
@@ -67,10 +67,11 @@ public:
 
     /*! Returns the index for a given parameter name, or -1 if name not found.
      *
-     * \name The name of the parameter to look up.
-     * \return The index of the parameter with the supplied name or -1 if not found.
+     * \param name The name of the parameter to look up.
+     * \param indexOut The output index if found.
+     * \return True if index found, false if not.
      */
-    int indexForParameterName(const std::string& name) const;
+    bool indexForParameterName(const std::string& name, size_t& indexOut) const;
 
     const std::string& name() const { return m_name; }
     const Shape* shape() const { return m_shape.get(); }
@@ -112,13 +113,12 @@ private:
      *        graph.
      * \return true if successful, false on error.
      */
-    bool groupVGens(int index, AbstractVGen::Rates rate, std::set<size_t>& computeVGens, std::set<size_t>& vertexVGens,
-                    std::set<size_t>& fragmentVGens);
+    bool groupVGens(size_t index, AbstractVGen::Rates rate, std::set<size_t>& computeVGens,
+                    std::set<size_t>& vertexVGens, std::set<size_t>& fragmentVGens);
 
     bool buildComputeStage(const std::set<size_t>& computeVGens);
     bool buildDrawStage(const std::set<size_t>& vertexVGens, const std::set<size_t>& fragmentVGens);
-    bool finalizeShaders(const std::set<size_t>& computeVGens, const std::set<size_t>& vertexVGens,
-                         const std::set<size_t>& fragmentVGens);
+    bool finalizeShaders();
 
     std::string m_name;
     std::unique_ptr<Shape> m_shape;
@@ -155,7 +155,7 @@ private:
 
     bool m_hasComputeStage;
 
-    std::unordered_map<std::string, int> m_parameterIndices;
+    std::unordered_map<std::string, size_t> m_parameterIndices;
 };
 
 } // namespace base

--- a/src/base/AbstractScinthDef_unittests.cpp
+++ b/src/base/AbstractScinthDef_unittests.cpp
@@ -247,7 +247,7 @@ TEST_F(AbstractScinthDefTest, BuildWithNormPosPixelRate) {
     // Vertex manifest should contain the position and the NormPos.
     std::unordered_set<Intrinsic> vertexIntrinsics { Intrinsic::kPosition, Intrinsic::kNormPos };
     ASSERT_EQ(2, def->vertexManifest().numberOfElements());
-    for (auto i = 0; i < def->vertexManifest().numberOfElements(); ++i) {
+    for (size_t i = 0; i < def->vertexManifest().numberOfElements(); ++i) {
         vertexIntrinsics.erase(def->vertexManifest().intrinsicForElement(i));
     }
     EXPECT_EQ(0, vertexIntrinsics.size());
@@ -303,7 +303,7 @@ TEST_F(AbstractScinthDefTest, BuildWithTexPosPixelRate) {
     // Vertex manifest should contain the position and the NormPos.
     std::unordered_set<Intrinsic> vertexIntrinsics { Intrinsic::kPosition, Intrinsic::kTexPos };
     ASSERT_EQ(2, def->vertexManifest().numberOfElements());
-    for (auto i = 0; i < def->vertexManifest().numberOfElements(); ++i) {
+    for (size_t i = 0; i < def->vertexManifest().numberOfElements(); ++i) {
         vertexIntrinsics.erase(def->vertexManifest().intrinsicForElement(i));
     }
     EXPECT_EQ(0, vertexIntrinsics.size());

--- a/src/base/AbstractScinthDef_unittests.cpp
+++ b/src/base/AbstractScinthDef_unittests.cpp
@@ -379,8 +379,9 @@ TEST_F(AbstractScinthDefTest, BuildPixelRateParams) {
     ASSERT_EQ(1, def->parameters().size());
     EXPECT_EQ("a", def->parameters()[0].name());
     EXPECT_EQ(0.5, def->parameters()[0].defaultValue());
-    EXPECT_EQ(0, def->indexForParameterName("a"));
-
+    size_t indexOfA = 1;
+    EXPECT_TRUE(def->indexForParameterName("a", indexOfA));
+    EXPECT_EQ(0, indexOfA);
     EXPECT_EQ(1, def->instances().size());
     EXPECT_EQ(0, def->computeFixedImages().size());
     EXPECT_EQ(0, def->drawFixedImages().size());

--- a/src/base/AbstractScinthDef_unittests.cpp
+++ b/src/base/AbstractScinthDef_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/AbstractScinthDef.hpp"
 #include "base/Archetypes.hpp"

--- a/src/base/AbstractVGen.cpp
+++ b/src/base/AbstractVGen.cpp
@@ -6,8 +6,8 @@ namespace scin { namespace base {
 
 AbstractVGen::AbstractVGen(const std::string& name, unsigned supportedRates, bool isSampler,
                            const std::vector<std::string>& inputs, const std::vector<std::string>& outputs,
-                           const std::vector<std::vector<int>> inputDimensions,
-                           const std::vector<std::vector<int>> outputDimensions, const std::string& shader):
+                           const std::vector<std::vector<size_t>> inputDimensions,
+                           const std::vector<std::vector<size_t>> outputDimensions, const std::string& shader):
     m_name(name),
     m_supportedRates(supportedRates),
     m_isSampler(isSampler),
@@ -23,7 +23,7 @@ AbstractVGen::~AbstractVGen() {}
 bool AbstractVGen::prepareTemplate() {
     // First build a map of all tokens (also verifying uniqueness of names in the process)
     std::unordered_map<std::string, Parameter> parameterMap;
-    for (auto i = 0; i < m_inputs.size(); ++i) {
+    for (size_t i = 0; i < m_inputs.size(); ++i) {
         if (parameterMap.find(m_inputs[i]) != parameterMap.end()) {
             spdlog::error("VGen {} has a duplicate parameter name {}", m_name, m_inputs[i]);
             return false;
@@ -34,7 +34,7 @@ bool AbstractVGen::prepareTemplate() {
         }
         parameterMap.insert({ m_inputs[i], Parameter(Parameter::Kind::kInput, i) });
     }
-    for (auto i = 0; i < m_outputs.size(); ++i) {
+    for (size_t i = 0; i < m_outputs.size(); ++i) {
         if (parameterMap.find(m_outputs[i]) != parameterMap.end()) {
             spdlog::error("VGen {} has a duplicate parameter name {}", m_name, m_outputs[i]);
             return false;
@@ -85,7 +85,7 @@ bool AbstractVGen::prepareTemplate() {
 std::string AbstractVGen::parameterize(const std::vector<std::string>& inputs,
                                        const std::unordered_map<Intrinsic, std::string>& intrinsics,
                                        const std::vector<std::string>& outputs,
-                                       const std::vector<int>& outputDimensions,
+                                       const std::vector<size_t>& outputDimensions,
                                        const std::unordered_set<std::string>& alreadyDefined) const {
     if (!m_valid) {
         spdlog::error("VGen {} parameterized but invalid.", m_name);
@@ -99,10 +99,10 @@ std::string AbstractVGen::parameterize(const std::vector<std::string>& inputs,
     }
 
     std::string shader;
-    size_t shaderPos = 0;
+    std::smatch::difference_type shaderPos = 0;
     // We keep a running list of the first time we encounter outputs in the shader code, because we will need to
     // declare them.
-    std::unordered_set<int> outputsEncountered;
+    std::unordered_set<size_t> outputsEncountered;
     for (auto param : m_parameters) {
         if (shaderPos < param.first.position()) {
             shader += m_shader.substr(shaderPos, param.first.position() - shaderPos);

--- a/src/base/AbstractVGen.hpp
+++ b/src/base/AbstractVGen.hpp
@@ -39,8 +39,8 @@ public:
      */
     AbstractVGen(const std::string& name, unsigned supportedRates, bool isSampler,
                  const std::vector<std::string>& inputs, const std::vector<std::string>& outputs,
-                 const std::vector<std::vector<int>> inputDimensions,
-                 const std::vector<std::vector<int>> outputDimensions, const std::string& shader);
+                 const std::vector<std::vector<size_t>> inputDimensions,
+                 const std::vector<std::vector<size_t>> outputDimensions, const std::string& shader);
     ~AbstractVGen();
 
     /*! Evaluate the provided shader and parameters, prepare for requests for parameterization.
@@ -62,7 +62,7 @@ public:
      */
     std::string parameterize(const std::vector<std::string>& inputs,
                              const std::unordered_map<Intrinsic, std::string>& intrinsics,
-                             const std::vector<std::string>& outputs, const std::vector<int>& outputDimensions,
+                             const std::vector<std::string>& outputs, const std::vector<size_t>& outputDimensions,
                              const std::unordered_set<std::string>& alreadyDefined) const;
 
     const std::string& name() const { return m_name; }
@@ -71,8 +71,8 @@ public:
     const std::vector<std::string>& inputs() const { return m_inputs; }
     const std::unordered_set<Intrinsic>& intrinsics() const { return m_intrinsics; }
     const std::vector<std::string>& outputs() const { return m_outputs; }
-    const std::vector<std::vector<int>>& inputDimensions() const { return m_inputDimensions; }
-    const std::vector<std::vector<int>>& outputDimensions() const { return m_outputDimensions; }
+    const std::vector<std::vector<size_t>>& inputDimensions() const { return m_inputDimensions; }
+    const std::vector<std::vector<size_t>>& outputDimensions() const { return m_outputDimensions; }
     const std::string& shader() const { return m_shader; }
     bool valid() const { return m_valid; }
 
@@ -94,8 +94,8 @@ private:
     bool m_isSampler;
     std::vector<std::string> m_inputs;
     std::vector<std::string> m_outputs;
-    std::vector<std::vector<int>> m_inputDimensions;
-    std::vector<std::vector<int>> m_outputDimensions;
+    std::vector<std::vector<size_t>> m_inputDimensions;
+    std::vector<std::vector<size_t>> m_outputDimensions;
     std::string m_shader;
 
     bool m_valid;

--- a/src/base/AbstractVGen_unittests.cpp
+++ b/src/base/AbstractVGen_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/AbstractVGen.hpp"
 #include "base/Intrinsic.hpp"

--- a/src/base/Archetypes.cpp
+++ b/src/base/Archetypes.cpp
@@ -12,15 +12,15 @@
 
 #if _MSC_VER
 // Disable MSVC warning on included yaml-cpp headers
-#pragma warning(push)
-#pragma warning(disable: 4996)
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
 #endif // _MSC_VER
 
 #include "yaml-cpp/exceptions.h"
 #include "yaml-cpp/yaml.h"
 
 #if _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #endif // _MSC_VER
 
 namespace scin { namespace base {
@@ -453,13 +453,13 @@ std::shared_ptr<AbstractScinthDef> Archetypes::extractSingleNode(const YAML::Nod
                         return nullptr;
                     }
                     size_t vgenIndex = input["vgenIndex"].as<size_t>();
-                    if (vgenIndex < 0 || vgenIndex > instances.size()) {
+                    if (vgenIndex > instances.size()) {
                         spdlog::error("ScinthDef {} has VGen {} vgen input with invalid index {}.", name, className,
                                       vgenIndex);
                         return nullptr;
                     }
                     size_t outputIndex = input["outputIndex"].as<size_t>();
-                    if (outputIndex < 0 || outputIndex >= instances[vgenIndex].abstractVGen()->outputs().size()) {
+                    if (outputIndex >= instances[vgenIndex].abstractVGen()->outputs().size()) {
                         spdlog::error("ScinthDef {} has VGen {} vgen input with invalid output index {}.", name,
                                       className, outputIndex);
                         return nullptr;

--- a/src/base/Archetypes.cpp
+++ b/src/base/Archetypes.cpp
@@ -441,13 +441,13 @@ std::shared_ptr<AbstractScinthDef> Archetypes::extractSingleNode(const YAML::Nod
                                       className);
                         return nullptr;
                     }
-                    int vgenIndex = input["vgenIndex"].as<int>();
+                    size_t vgenIndex = input["vgenIndex"].as<size_t>();
                     if (vgenIndex < 0 || vgenIndex > instances.size()) {
                         spdlog::error("ScinthDef {} has VGen {} vgen input with invalid index {}.", name, className,
                                       vgenIndex);
                         return nullptr;
                     }
-                    int outputIndex = input["outputIndex"].as<int>();
+                    size_t outputIndex = input["outputIndex"].as<size_t>();
                     if (outputIndex < 0 || outputIndex >= instances[vgenIndex].abstractVGen()->outputs().size()) {
                         spdlog::error("ScinthDef {} has VGen {} vgen input with invalid output index {}.", name,
                                       className, outputIndex);
@@ -459,7 +459,7 @@ std::shared_ptr<AbstractScinthDef> Archetypes::extractSingleNode(const YAML::Nod
                         spdlog::error("ScinthDef {} has VGen {} parameter input with no index key.", name, className);
                         return nullptr;
                     }
-                    int parameterIndex = input["index"].as<int>();
+                    size_t parameterIndex = input["index"].as<size_t>();
                     instance.addParameterInput(parameterIndex);
                 }
             }
@@ -553,8 +553,8 @@ int Archetypes::extractAbstractVGensFromNodes(const std::vector<YAML::Node>& nod
             spdlog::error("VGen {} dimensions tag absent or not a sequence.", name);
             continue;
         }
-        std::vector<std::vector<int>> inputDimensions;
-        std::vector<std::vector<int>> outputDimensions;
+        std::vector<std::vector<size_t>> inputDimensions;
+        std::vector<std::vector<size_t>> outputDimensions;
         for (auto dim : node["dimensions"]) {
             if (!dim.IsMap()) {
                 spdlog::error("VGen {} has dimensions list element that is not a map.", name);
@@ -562,14 +562,14 @@ int Archetypes::extractAbstractVGensFromNodes(const std::vector<YAML::Node>& nod
             }
 
             // The input tag is optional for those VGens that don't have inputs.
-            std::vector<int> inputDims;
+            std::vector<size_t> inputDims;
             if (dim["inputs"]) {
                 // If only a single number provided use that as dimension for all inputs.
                 if (dim["inputs"].IsScalar()) {
-                    inputDims.insert(inputDims.begin(), inputs.size(), dim["inputs"].as<int>());
+                    inputDims.insert(inputDims.begin(), inputs.size(), dim["inputs"].as<size_t>());
                 } else if (dim["inputs"].IsSequence()) {
                     for (auto inDim : dim["inputs"]) {
-                        inputDims.push_back(inDim.as<int>());
+                        inputDims.push_back(inDim.as<size_t>());
                     }
                 } else {
                     spdlog::error("VGen {} has malformed inputs tag inside of dimension list.", name);
@@ -583,12 +583,12 @@ int Archetypes::extractAbstractVGensFromNodes(const std::vector<YAML::Node>& nod
                 spdlog::error("VGen {} missing output tag inside of dimension list.", name);
                 break;
             }
-            std::vector<int> outputDims;
+            std::vector<size_t> outputDims;
             if (dim["outputs"].IsScalar()) {
-                outputDims.insert(outputDims.begin(), outputs.size(), dim["outputs"].as<int>());
+                outputDims.insert(outputDims.begin(), outputs.size(), dim["outputs"].as<size_t>());
             } else if (dim["outputs"].IsSequence()) {
                 for (auto outDim : dim["outputs"]) {
-                    outputDims.push_back(outDim.as<int>());
+                    outputDims.push_back(outDim.as<size_t>());
                 }
             } else {
                 spdlog::error("VGen {} has malformed outputs tag inside of dimension list.", name);
@@ -605,7 +605,7 @@ int Archetypes::extractAbstractVGensFromNodes(const std::vector<YAML::Node>& nod
         }
         // Each entry in input dimensions list should match the number of inputs, and same with outputs.
         bool dimensionsValid = true;
-        for (auto i = 0; i < outputDimensions.size(); ++i) {
+        for (size_t i = 0; i < outputDimensions.size(); ++i) {
             if (outputDimensions[i].size() != outputs.size()) {
                 spdlog::error("VGen {} has output dimensions list of unequal size to the number of outputs.", name);
                 dimensionsValid = false;

--- a/src/base/Archetypes.cpp
+++ b/src/base/Archetypes.cpp
@@ -9,8 +9,19 @@
 #include "base/VGen.hpp"
 
 #include "spdlog/spdlog.h"
+
+#if _MSC_VER
+// Disable MSVC warning on included yaml-cpp headers
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif // _MSC_VER
+
 #include "yaml-cpp/exceptions.h"
 #include "yaml-cpp/yaml.h"
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
 
 namespace scin { namespace base {
 
@@ -193,13 +204,13 @@ std::shared_ptr<AbstractScinthDef> Archetypes::extractSingleNode(const YAML::Nod
     }
     auto shapeName = shapeNode["name"].as<std::string>();
     if (shapeName == "Quad") {
-        int widthEdges = 1;
-        int heightEdges = 1;
+        uint16_t widthEdges = 1;
+        uint16_t heightEdges = 1;
         if (shapeNode["widthEdges"] && shapeNode["widthEdges"].IsScalar()) {
-            widthEdges = shapeNode["widthEdges"].as<int>();
+            widthEdges = shapeNode["widthEdges"].as<uint16_t>();
         }
         if (shapeNode["heightEdges"] && shapeNode["heightEdges"].IsScalar()) {
-            heightEdges = shapeNode["heightEdges"].as<int>();
+            heightEdges = shapeNode["heightEdges"].as<uint16_t>();
         }
         shape.reset(new Quad(widthEdges, heightEdges));
     } else {

--- a/src/base/Archetypes_unittests.cpp
+++ b/src/base/Archetypes_unittests.cpp
@@ -338,13 +338,13 @@ TEST(ArchetypesTest, ValidYAMLStrings) {
     EXPECT_EQ("OneInput", scinthDef->instances()[0].abstractVGen()->name());
     ASSERT_EQ(1, scinthDef->instances()[0].numberOfInputs());
     float inputValue = 0.0f;
-    int vgenIndex = -1;
-    int outputIndex = -2;
+    size_t vgenIndex = 0xfffff;
+    size_t outputIndex = 0xffffe;
     EXPECT_TRUE(scinthDef->instances()[0].getInputConstantValue(0, inputValue));
     EXPECT_FALSE(scinthDef->instances()[0].getInputVGenIndex(0, vgenIndex, outputIndex));
     EXPECT_EQ(-123.0f, inputValue);
-    EXPECT_EQ(-1, vgenIndex); // vgenIndex should remain unmodified as the input is a constant.
-    EXPECT_EQ(-2, outputIndex);
+    EXPECT_EQ(0xfffff, vgenIndex); // vgenIndex should remain unmodified as the input is a constant.
+    EXPECT_EQ(0xffffe, outputIndex);
     EXPECT_EQ("TwoInput", scinthDef->instances()[1].abstractVGen()->name());
     ASSERT_EQ(2, scinthDef->instances()[1].numberOfInputs());
     EXPECT_FALSE(scinthDef->instances()[1].getInputConstantValue(0, inputValue));

--- a/src/base/Archetypes_unittests.cpp
+++ b/src/base/Archetypes_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/AbstractScinthDef.hpp"
 #include "base/AbstractVGen.hpp"

--- a/src/base/GTestIncludes.hpp
+++ b/src/base/GTestIncludes.hpp
@@ -1,0 +1,15 @@
+#ifndef SRC_BASE_GTEST_INCLUDES_HPP_
+#define SRC_BASE_GTEST_INCLUDES_HPP_
+
+#if _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4389)
+#endif
+
+#include <gtest/gtest.h>
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif
+
+#endif // SRC_BASE_GTEST_INCLUDES_HPP_

--- a/src/base/GTestIncludes.hpp
+++ b/src/base/GTestIncludes.hpp
@@ -2,14 +2,14 @@
 #define SRC_BASE_GTEST_INCLUDES_HPP_
 
 #if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4389)
+#    pragma warning(push)
+#    pragma warning(disable : 4389)
 #endif
 
 #include <gtest/gtest.h>
 
 #if _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #endif
 
 #endif // SRC_BASE_GTEST_INCLUDES_HPP_

--- a/src/base/Intrinsic.cpp.in
+++ b/src/base/Intrinsic.cpp.in
@@ -27,8 +27,7 @@ vTexPos,    scin::base::Intrinsic::kTexPos
 namespace scin { namespace base {
 
 Intrinsic getIntrinsicNamed(const std::string& name) {
-    unsigned int length = static_cast<unsigned int>(name.size());
-    const IntrinsicPair* pair = Perfect_Hash::in_word_set(name.data(), length);
+    const IntrinsicPair* pair = Perfect_Hash::in_word_set(name.data(), name.size());
     if (!pair) {
         return Intrinsic::kNotFound;
     }

--- a/src/base/Intrinsic.cpp.in
+++ b/src/base/Intrinsic.cpp.in
@@ -13,13 +13,13 @@ namespace {
 %struct-type
 struct IntrinsicPair { const char* name; scin::base::Intrinsic intrinsic; };
 %%
-vFragCoord,  scin::base::Intrinsic::kFragCoord
-vNormPos,    scin::base::Intrinsic::kNormPos
+vFragCoord, scin::base::Intrinsic::kFragCoord
+vNormPos,   scin::base::Intrinsic::kNormPos
 pi,         scin::base::Intrinsic::kPi
 position,   scin::base::Intrinsic::kPosition
 sampler,    scin::base::Intrinsic::kSampler
 time,       scin::base::Intrinsic::kTime
-vTexPos,     scin::base::Intrinsic::kTexPos
+vTexPos,    scin::base::Intrinsic::kTexPos
 %%
 
 } // namespace
@@ -27,7 +27,8 @@ vTexPos,     scin::base::Intrinsic::kTexPos
 namespace scin { namespace base {
 
 Intrinsic getIntrinsicNamed(const std::string& name) {
-    const IntrinsicPair* pair = Perfect_Hash::in_word_set(name.data(), name.size());
+    unsigned int length = static_cast<unsigned int>(name.size());
+    const IntrinsicPair* pair = Perfect_Hash::in_word_set(name.data(), length);
     if (!pair) {
         return Intrinsic::kNotFound;
     }

--- a/src/base/Intrinsic.cpp.in
+++ b/src/base/Intrinsic.cpp.in
@@ -9,7 +9,10 @@
 // Disable MSVC warning on generated code.
 #pragma warning(push)
 #pragma warning(disable: 4267)
-#endif // _MSC_VER
+#elif __GNUC__ || __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
 namespace {
 
@@ -32,7 +35,9 @@ vTexPos,    scin::base::Intrinsic::kTexPos
 
 #if _MSC_VER
 #pragma warning(pop)
-#endif // _MSC_VER
+#elif __GNUC__ || __clang__
+#pragma GCC diagnostic pop
+#endif
 
 namespace scin { namespace base {
 

--- a/src/base/Intrinsic.cpp.in
+++ b/src/base/Intrinsic.cpp.in
@@ -5,10 +5,6 @@
 
 #include <cstring>
 
-// Some of the gperf generated code uses the register keyword, which is deprecated in C++17.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wregister"
-
 namespace {
 
 %}
@@ -27,8 +23,6 @@ vTexPos,     scin::base::Intrinsic::kTexPos
 %%
 
 } // namespace
-
-#pragma clang diagnostic pop
 
 namespace scin { namespace base {
 

--- a/src/base/Intrinsic.cpp.in
+++ b/src/base/Intrinsic.cpp.in
@@ -5,6 +5,12 @@
 
 #include <cstring>
 
+#if _MSC_VER
+// Disable MSVC warning on generated code.
+#pragma warning(push)
+#pragma warning(disable: 4267)
+#endif // _MSC_VER
+
 namespace {
 
 %}
@@ -23,6 +29,10 @@ vTexPos,    scin::base::Intrinsic::kTexPos
 %%
 
 } // namespace
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
 
 namespace scin { namespace base {
 

--- a/src/base/Manifest_unittests.cpp
+++ b/src/base/Manifest_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/Manifest.hpp"
 

--- a/src/base/Manifest_unittests.cpp
+++ b/src/base/Manifest_unittests.cpp
@@ -32,7 +32,7 @@ TEST(ManifestTest, HomogeneousTypes) {
     EXPECT_EQ(3 * sizeof(float), allFloats.sizeInBytes());
     // All floats should be aligned on their size and represented in the manifest.
     std::unordered_set<std::string> allFloatNames;
-    for (auto i = 0; i < allFloats.numberOfElements(); ++i) {
+    for (size_t i = 0; i < allFloats.numberOfElements(); ++i) {
         EXPECT_EQ("float", allFloats.typeNameForElement(i));
         EXPECT_EQ(sizeof(float), allFloats.strideForElement(i));
         EXPECT_EQ(i * sizeof(float), allFloats.offsetForElement(i));

--- a/src/base/Shape.cpp
+++ b/src/base/Shape.cpp
@@ -34,7 +34,7 @@ bool Quad::storeVertexData(const Manifest& vertexManifest, const glm::vec2& norm
         float y = static_cast<float>(i) / static_cast<float>(m_heightEdges);
         for (auto j = 0; j <= m_widthEdges; ++j) {
             glm::vec2 v { static_cast<float>(j) / static_cast<float>(m_widthEdges), y };
-            for (auto k = 0; k < vertexManifest.numberOfElements(); ++k) {
+            for (size_t k = 0; k < vertexManifest.numberOfElements(); ++k) {
                 switch (vertexManifest.intrinsicForElement(k)) {
                 case kNormPos: {
                     glm::vec2 normPos = (upperLeft + (v * 2.0f)) * normPosScale;

--- a/src/base/Shape.cpp
+++ b/src/base/Shape.cpp
@@ -28,7 +28,6 @@ Shape::Topology Quad::topology() const { return kTriangleStrip; }
 
 bool Quad::storeVertexData(const Manifest& vertexManifest, const glm::vec2& normPosScale, float* store) const {
     glm::vec2 upperLeft { -1.0f, -1.0f };
-    glm::vec2 lowerRight { 1.0f, 1.0f };
 
     for (auto i = 0; i <= m_heightEdges; ++i) {
         float y = static_cast<float>(i) / static_cast<float>(m_heightEdges);

--- a/src/base/Shape.cpp
+++ b/src/base/Shape.cpp
@@ -9,7 +9,7 @@ namespace scin { namespace base {
 Shape::Shape() {}
 Shape::~Shape() {}
 
-Quad::Quad(int widthEdges, int heightEdges): m_widthEdges(widthEdges), m_heightEdges(heightEdges) {}
+Quad::Quad(uint16_t widthEdges, uint16_t heightEdges): m_widthEdges(widthEdges), m_heightEdges(heightEdges) {}
 Quad::~Quad() {}
 
 Manifest::ElementType Quad::elementType() const { return Manifest::ElementType::kVec2; }
@@ -66,9 +66,9 @@ bool Quad::storeVertexData(const Manifest& vertexManifest, const glm::vec2& norm
 
 bool Quad::storeIndexData(uint16_t* store) const {
     uint16_t widthVerts = m_widthEdges + 1;
-    for (auto i = 0; i < m_heightEdges; ++i) {
+    for (uint16_t i = 0; i < m_heightEdges; ++i) {
         uint16_t rowStart = i * widthVerts;
-        for (auto j = 0; j <= m_widthEdges; ++j) {
+        for (uint16_t j = 0; j <= m_widthEdges; ++j) {
             uint16_t topIndex = j + rowStart;
             store[0] = topIndex;
             store[1] = topIndex + widthVerts;

--- a/src/base/Shape.hpp
+++ b/src/base/Shape.hpp
@@ -52,7 +52,7 @@ public:
  */
 class Quad : public Shape {
 public:
-    Quad(int widthEdges, int heightEdges);
+    Quad(uint16_t widthEdges, uint16_t heightEdges);
     virtual ~Quad();
 
     Manifest::ElementType elementType() const override;
@@ -64,8 +64,8 @@ public:
     bool storeIndexData(uint16_t* store) const override;
 
 private:
-    int m_widthEdges;
-    int m_heightEdges;
+    uint16_t m_widthEdges;
+    uint16_t m_heightEdges;
 };
 
 } // namespace base

--- a/src/base/Shape_unittests.cpp
+++ b/src/base/Shape_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/Manifest.hpp"
 #include "base/Shape.hpp"

--- a/src/base/Shape_unittests.cpp
+++ b/src/base/Shape_unittests.cpp
@@ -29,7 +29,7 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
     // Vertices should run from left to right, top to bottom, like reading a page of English text. So first vertex
     // should describe top left.
     const float* verts = vertexData.get();
-    for (auto i = 0; i < manifest.numberOfElements(); ++i) {
+    for (size_t i = 0; i < manifest.numberOfElements(); ++i) {
         switch (manifest.intrinsicForElement(i)) {
         case Intrinsic::kPosition:
             EXPECT_EQ(-1.0f, verts[0]);
@@ -44,6 +44,10 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
         case Intrinsic::kTexPos:
             EXPECT_EQ(0.0f, verts[0]);
             EXPECT_EQ(0.0f, verts[1]);
+            break;
+
+        default:
+            ASSERT_TRUE(false);
             break;
         }
 
@@ -52,7 +56,7 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
 
     // Second vertex should describe top right vertex.
     verts = vertexData.get() + (manifest.sizeInBytes() / sizeof(float));
-    for (auto i = 0; i < manifest.numberOfElements(); ++i) {
+    for (size_t i = 0; i < manifest.numberOfElements(); ++i) {
         switch (manifest.intrinsicForElement(i)) {
         case Intrinsic::kPosition:
             EXPECT_EQ(1.0f, verts[0]);
@@ -68,6 +72,10 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
             EXPECT_EQ(1.0f, verts[0]);
             EXPECT_EQ(0.0f, verts[1]);
             break;
+
+        default:
+            ASSERT_TRUE(false);
+            break;
         }
 
         verts += manifest.strideForElement(i) / sizeof(float);
@@ -75,7 +83,7 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
 
     // Third vertex should describe lower left vertex.
     verts = vertexData.get() + (2 * manifest.sizeInBytes() / sizeof(float));
-    for (auto i = 0; i < manifest.numberOfElements(); ++i) {
+    for (size_t i = 0; i < manifest.numberOfElements(); ++i) {
         switch (manifest.intrinsicForElement(i)) {
         case Intrinsic::kPosition:
             EXPECT_EQ(-1.0f, verts[0]);
@@ -91,6 +99,10 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
             EXPECT_EQ(0.0f, verts[0]);
             EXPECT_EQ(1.0f, verts[1]);
             break;
+
+        default:
+            ASSERT_TRUE(false);
+            break;
         }
 
         verts += manifest.strideForElement(i) / sizeof(float);
@@ -98,7 +110,7 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
 
     // Fourth vertex should describe lower right vertex.
     verts = vertexData.get() + (3 * manifest.sizeInBytes() / sizeof(float));
-    for (auto i = 0; i < manifest.numberOfElements(); ++i) {
+    for (size_t i = 0; i < manifest.numberOfElements(); ++i) {
         switch (manifest.intrinsicForElement(i)) {
         case Intrinsic::kPosition:
             EXPECT_EQ(1.0f, verts[0]);
@@ -113,6 +125,10 @@ TEST(QuadTest, SingleEdgesInWidthAndHeight) {
         case Intrinsic::kTexPos:
             EXPECT_EQ(1.0f, verts[0]);
             EXPECT_EQ(1.0f, verts[1]);
+            break;
+
+        default:
+            ASSERT_TRUE(false);
             break;
         }
 

--- a/src/base/VGen.cpp
+++ b/src/base/VGen.cpp
@@ -10,7 +10,7 @@ VGen::VGen(std::shared_ptr<const AbstractVGen> abstractVGen, AbstractVGen::Rates
 
 VGen::~VGen() {}
 
-void VGen::setSamplerConfig(int imageIndex, InputType imageArgType, const AbstractSampler& sampler) {
+void VGen::setSamplerConfig(size_t imageIndex, InputType imageArgType, const AbstractSampler& sampler) {
     m_imageIndex = imageIndex;
     m_imageArgType = imageArgType;
     m_abstractSampler = sampler;
@@ -21,13 +21,13 @@ void VGen::addConstantInput(glm::vec2 constantValue) { m_inputs.emplace_back(VGe
 void VGen::addConstantInput(glm::vec3 constantValue) { m_inputs.emplace_back(VGenInput(constantValue)); }
 void VGen::addConstantInput(glm::vec4 constantValue) { m_inputs.emplace_back(VGenInput(constantValue)); }
 
-void VGen::addParameterInput(int parameterIndex) { m_inputs.emplace_back(VGenInput(parameterIndex)); }
+void VGen::addParameterInput(size_t parameterIndex) { m_inputs.emplace_back(VGenInput(parameterIndex)); }
 
-void VGen::addVGenInput(int vgenIndex, int outputIndex, int dimension) {
+void VGen::addVGenInput(size_t vgenIndex, size_t outputIndex, size_t dimension) {
     m_inputs.emplace_back(VGenInput(vgenIndex, outputIndex, dimension));
 }
 
-void VGen::addOutput(int dimension) { m_outputDimensions.push_back(dimension); }
+void VGen::addOutput(size_t dimension) { m_outputDimensions.push_back(dimension); }
 
 bool VGen::validate() const {
     if (m_inputs.size() != m_abstractVGen->inputs().size()) {
@@ -46,14 +46,14 @@ bool VGen::validate() const {
     return true;
 }
 
-VGen::InputType VGen::getInputType(int index) const {
+VGen::InputType VGen::getInputType(size_t index) const {
     if (index >= 0 && index < numberOfInputs()) {
         return m_inputs[index].type;
     }
     return kInvalid;
 }
 
-bool VGen::getInputConstantValue(int index, float& outValue) const {
+bool VGen::getInputConstantValue(size_t index, float& outValue) const {
     if (index >= 0 && index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 1) {
             outValue = m_inputs[index].value.constant1;
@@ -63,7 +63,7 @@ bool VGen::getInputConstantValue(int index, float& outValue) const {
     return false;
 }
 
-bool VGen::getInputConstantValue(int index, glm::vec2& outValue) const {
+bool VGen::getInputConstantValue(size_t index, glm::vec2& outValue) const {
     if (index >= 0 && index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 2) {
             outValue = m_inputs[index].value.constant2;
@@ -73,7 +73,7 @@ bool VGen::getInputConstantValue(int index, glm::vec2& outValue) const {
     return false;
 }
 
-bool VGen::getInputConstantValue(int index, glm::vec3& outValue) const {
+bool VGen::getInputConstantValue(size_t index, glm::vec3& outValue) const {
     if (index >= 0 && index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 3) {
             outValue = m_inputs[index].value.constant3;
@@ -83,7 +83,7 @@ bool VGen::getInputConstantValue(int index, glm::vec3& outValue) const {
     return false;
 }
 
-bool VGen::getInputConstantValue(int index, glm::vec4& outValue) const {
+bool VGen::getInputConstantValue(size_t index, glm::vec4& outValue) const {
     if (index >= 0 && index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 4) {
             outValue = m_inputs[index].value.constant4;
@@ -93,7 +93,7 @@ bool VGen::getInputConstantValue(int index, glm::vec4& outValue) const {
     return false;
 }
 
-bool VGen::getInputParameterIndex(int index, int& outIndex) const {
+bool VGen::getInputParameterIndex(size_t index, size_t& outIndex) const {
     if (index >= 0 && index < numberOfInputs()) {
         if (m_inputs[index].type == kParameter) {
             outIndex = m_inputs[index].value.parameterIndex;
@@ -103,11 +103,11 @@ bool VGen::getInputParameterIndex(int index, int& outIndex) const {
     return false;
 }
 
-bool VGen::getInputVGenIndex(int index, int& outIndex, int& outOutput) const {
+bool VGen::getInputVGenIndex(size_t index, size_t& outIndex, size_t& outOutput) const {
     if (index >= 0 && index < numberOfInputs()) {
         if (m_inputs[index].type == kVGen) {
-            outIndex = m_inputs[index].value.vgen.x;
-            outOutput = m_inputs[index].value.vgen.y;
+            outIndex = m_inputs[index].value.vgenIndex;
+            outOutput = m_inputs[index].vgenOutputIndex;
             return true;
         }
     }

--- a/src/base/VGen.cpp
+++ b/src/base/VGen.cpp
@@ -47,14 +47,14 @@ bool VGen::validate() const {
 }
 
 VGen::InputType VGen::getInputType(size_t index) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         return m_inputs[index].type;
     }
     return kInvalid;
 }
 
 bool VGen::getInputConstantValue(size_t index, float& outValue) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 1) {
             outValue = m_inputs[index].value.constant1;
             return true;
@@ -64,7 +64,7 @@ bool VGen::getInputConstantValue(size_t index, float& outValue) const {
 }
 
 bool VGen::getInputConstantValue(size_t index, glm::vec2& outValue) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 2) {
             outValue = m_inputs[index].value.constant2;
             return true;
@@ -74,7 +74,7 @@ bool VGen::getInputConstantValue(size_t index, glm::vec2& outValue) const {
 }
 
 bool VGen::getInputConstantValue(size_t index, glm::vec3& outValue) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 3) {
             outValue = m_inputs[index].value.constant3;
             return true;
@@ -84,7 +84,7 @@ bool VGen::getInputConstantValue(size_t index, glm::vec3& outValue) const {
 }
 
 bool VGen::getInputConstantValue(size_t index, glm::vec4& outValue) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         if (m_inputs[index].type == kConstant && m_inputs[index].dimension == 4) {
             outValue = m_inputs[index].value.constant4;
             return true;
@@ -94,7 +94,7 @@ bool VGen::getInputConstantValue(size_t index, glm::vec4& outValue) const {
 }
 
 bool VGen::getInputParameterIndex(size_t index, size_t& outIndex) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         if (m_inputs[index].type == kParameter) {
             outIndex = m_inputs[index].value.parameterIndex;
             return true;
@@ -104,7 +104,7 @@ bool VGen::getInputParameterIndex(size_t index, size_t& outIndex) const {
 }
 
 bool VGen::getInputVGenIndex(size_t index, size_t& outIndex, size_t& outOutput) const {
-    if (index >= 0 && index < numberOfInputs()) {
+    if (index < numberOfInputs()) {
         if (m_inputs[index].type == kVGen) {
             outIndex = m_inputs[index].value.vgenIndex;
             outOutput = m_inputs[index].vgenOutputIndex;

--- a/src/base/VGen.hpp
+++ b/src/base/VGen.hpp
@@ -23,7 +23,7 @@ public:
     /*! Sets the sampler configuration information for this VGen instance. This information will be ignored on
      * non-sampling VGens.
      */
-    void setSamplerConfig(int imageIndex, InputType imageArgType, const AbstractSampler& sampler);
+    void setSamplerConfig(size_t imageIndex, InputType imageArgType, const AbstractSampler& sampler);
 
     /*! Adds a single-dimensional constant-valued input.
      *
@@ -38,7 +38,7 @@ public:
      *
      * \param parameterIndex The index of the parameter in the overall parameter list.
      */
-    void addParameterInput(int parameterIndex);
+    void addParameterInput(size_t parameterIndex);
 
     /*! Add output from another VGen as input.
      *
@@ -47,14 +47,14 @@ public:
      * \param outputIndex The index of the output from the VGen use as input.
      * \param dimension The dimension of the input.
      */
-    void addVGenInput(int vgenIndex, int outputIndex, int dimension);
+    void addVGenInput(size_t vgenIndex, size_t outputIndex, size_t dimension);
 
 
     /*! Add an output to this VGen with supplied dimension.
      *
      * \param dimension The dimension of the output.
      */
-    void addOutput(int dimension);
+    void addOutput(size_t dimension);
 
     /*! Check this instance data against the originating AbstractVGen.
      *
@@ -67,7 +67,7 @@ public:
      * \param index The index of the input in question.
      * \return InputType an enumeration of the type of input, or kInvalid on error.
      */
-    InputType getInputType(int index) const;
+    InputType getInputType(size_t index) const;
 
     /*! If the input at index is a constant, return true and store the constant value in outValue.
      *
@@ -75,10 +75,10 @@ public:
      * \param outValue Will be set to the value of the constant on successful completion of the function.
      * \return true if the input at index is a constant, false otherwise.
      */
-    bool getInputConstantValue(int index, float& outValue) const;
-    bool getInputConstantValue(int index, glm::vec2& outValue) const;
-    bool getInputConstantValue(int index, glm::vec3& outValue) const;
-    bool getInputConstantValue(int index, glm::vec4& outValue) const;
+    bool getInputConstantValue(size_t index, float& outValue) const;
+    bool getInputConstantValue(size_t index, glm::vec2& outValue) const;
+    bool getInputConstantValue(size_t index, glm::vec3& outValue) const;
+    bool getInputConstantValue(size_t index, glm::vec4& outValue) const;
 
     /*! If the input at index is a parameter, return true and store the parameter index value in outIndex.
      *
@@ -86,7 +86,7 @@ public:
      * \param outIndex The index of the parameter input assoicated with this VGen input.
      * \return true if the input at index is a parameter, false otherwise.
      */
-    bool getInputParameterIndex(int index, int& outIndex) const;
+    bool getInputParameterIndex(size_t index, size_t& outIndex) const;
 
     /*! If the input at index is a VGen, return true and store the vgen index value in outIndex.
      *
@@ -95,51 +95,54 @@ public:
      * \param outOutput Will be set to the value of the index of the output on the selected VGen.
      * \return true if the input at index is a VGen, false otherwise.
      */
-    bool getInputVGenIndex(int index, int& outIndex, int& outOutput) const;
+    bool getInputVGenIndex(size_t index, size_t& outIndex, size_t& outOutput) const;
 
-    int numberOfInputs() const { return m_inputs.size(); }
+    size_t numberOfInputs() const { return m_inputs.size(); }
 
-    int numberOfOutputs() const { return m_outputDimensions.size(); }
-    int outputDimension(int index) const { return m_outputDimensions[index]; }
+    size_t numberOfOutputs() const { return m_outputDimensions.size(); }
+    size_t outputDimension(size_t index) const { return m_outputDimensions[index]; }
 
     std::shared_ptr<const AbstractVGen> abstractVGen() const { return m_abstractVGen; }
     AbstractVGen::Rates rate() const { return m_rate; }
 
-    int imageIndex() const { return m_imageIndex; }
+    size_t imageIndex() const { return m_imageIndex; }
     InputType imageArgType() const { return m_imageArgType; }
     const AbstractSampler& sampler() const { return m_abstractSampler; }
 
 private:
     struct VGenInput {
-        explicit VGenInput(float c): type(kConstant), dimension(1) { value.constant1 = c; }
-        explicit VGenInput(glm::vec2 c): type(kConstant), dimension(2) { value.constant2 = c; }
-        explicit VGenInput(glm::vec3 c): type(kConstant), dimension(3) { value.constant3 = c; }
-        explicit VGenInput(glm::vec4 c): type(kConstant), dimension(4) { value.constant4 = c; }
-        explicit VGenInput(int index, int out, int dim): type(kVGen), dimension(dim) {
-            value.vgen = glm::ivec2(index, out);
+        explicit VGenInput(float c): type(kConstant), dimension(1), vgenOutputIndex(0) { value.constant1 = c; }
+        explicit VGenInput(glm::vec2 c): type(kConstant), dimension(2), vgenOutputIndex(0) { value.constant2 = c; }
+        explicit VGenInput(glm::vec3 c): type(kConstant), dimension(3), vgenOutputIndex(0) { value.constant3 = c; }
+        explicit VGenInput(glm::vec4 c): type(kConstant), dimension(4), vgenOutputIndex(0) { value.constant4 = c; }
+        explicit VGenInput(size_t index, size_t out, size_t dim): type(kVGen), dimension(dim), vgenOutputIndex(out) {
+            value.vgenIndex = index;
         }
-        explicit VGenInput(int paramIndex): type(kParameter), dimension(1) { value.parameterIndex = paramIndex; }
+        explicit VGenInput(size_t paramIndex): type(kParameter), dimension(1), vgenOutputIndex(0) {
+            value.parameterIndex = paramIndex;
+        }
 
         InputType type;
-        int dimension;
+        size_t dimension;
         union Value {
             float constant1;
-            int parameterIndex;
+            size_t parameterIndex;
             glm::vec2 constant2;
             glm::vec3 constant3;
             glm::vec4 constant4;
-            glm::ivec2 vgen;
+            size_t vgenIndex;
         };
         Value value;
+        size_t vgenOutputIndex;
     };
 
     std::shared_ptr<const AbstractVGen> m_abstractVGen;
     AbstractVGen::Rates m_rate;
-    int m_imageIndex;
+    size_t m_imageIndex;
     InputType m_imageArgType;
     AbstractSampler m_abstractSampler;
     std::vector<VGenInput> m_inputs;
-    std::vector<int> m_outputDimensions;
+    std::vector<size_t> m_outputDimensions;
 };
 
 } // namespace base

--- a/src/base/VGen_unittests.cpp
+++ b/src/base/VGen_unittests.cpp
@@ -44,8 +44,8 @@ TEST(VGenTest, InputValuesAndTypesRetained) {
     allConstants.addConstantInput(2.0f);
     allConstants.addConstantInput(45.0f);
     float constantValue = 0.0f;
-    int vgenIndex = 0;
-    int outputIndex = 0;
+    size_t vgenIndex = 0;
+    size_t outputIndex = 0;
     EXPECT_TRUE(allConstants.getInputConstantValue(0, constantValue));
     EXPECT_EQ(-1.0f, constantValue);
     EXPECT_FALSE(allConstants.getInputVGenIndex(0, vgenIndex, outputIndex));

--- a/src/base/VGen_unittests.cpp
+++ b/src/base/VGen_unittests.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base/GTestIncludes.hpp"
 
 #include "base/AbstractVGen.hpp"
 #include "base/Intrinsic.hpp"
@@ -76,64 +76,56 @@ TEST(VGenTest, InputValuesAndTypesRetained) {
     allVGens.addVGenInput(3, 4, 2);
     allVGens.addVGenInput(0, 0, 3);
     constantValue = 0.0f;
-    vgenIndex = -1;
-    outputIndex = -2;
     EXPECT_FALSE(allVGens.getInputConstantValue(0, constantValue));
     EXPECT_EQ(0.0f, constantValue);
     EXPECT_TRUE(allVGens.getInputVGenIndex(0, vgenIndex, outputIndex));
     EXPECT_EQ(2, vgenIndex);
     EXPECT_EQ(1, outputIndex);
-    vgenIndex = -1;
-    outputIndex = -2;
     EXPECT_FALSE(allVGens.getInputConstantValue(1, constantValue));
     EXPECT_EQ(0.0f, constantValue);
     EXPECT_TRUE(allVGens.getInputVGenIndex(1, vgenIndex, outputIndex));
     EXPECT_EQ(3, vgenIndex);
     EXPECT_EQ(4, outputIndex);
-    vgenIndex = -1;
-    outputIndex = -2;
     EXPECT_FALSE(allVGens.getInputConstantValue(2, constantValue));
     EXPECT_EQ(0.0f, constantValue);
     EXPECT_TRUE(allVGens.getInputVGenIndex(2, vgenIndex, outputIndex));
     EXPECT_EQ(0, vgenIndex);
     EXPECT_EQ(0, outputIndex);
-    vgenIndex = -1;
-    outputIndex = -2;
     EXPECT_FALSE(allVGens.getInputConstantValue(3, constantValue));
     EXPECT_EQ(0.0f, constantValue);
+    vgenIndex = 10;
+    outputIndex = 12;
     EXPECT_FALSE(allVGens.getInputVGenIndex(3, vgenIndex, outputIndex));
-    EXPECT_EQ(-1, vgenIndex);
-    EXPECT_EQ(-2, outputIndex);
+    EXPECT_EQ(10, vgenIndex);
+    EXPECT_EQ(12, outputIndex);
     EXPECT_TRUE(allVGens.validate());
 
     VGen pickAndMix(threeInputs, AbstractVGen::Rates::kPixel);
     pickAndMix.addConstantInput(-23.7f);
     pickAndMix.addVGenInput(14, 7, 3);
-    pickAndMix.addConstantInput(12224.3);
+    pickAndMix.addConstantInput(12224.3f);
     constantValue = 0.0f;
-    vgenIndex = -1;
-    outputIndex = -2;
+    vgenIndex = 11;
+    outputIndex = 13;
     EXPECT_TRUE(pickAndMix.getInputConstantValue(0, constantValue));
     EXPECT_EQ(-23.7f, constantValue);
     EXPECT_FALSE(pickAndMix.getInputVGenIndex(0, vgenIndex, outputIndex));
-    EXPECT_EQ(-1, vgenIndex);
-    EXPECT_EQ(-2, outputIndex);
+    EXPECT_EQ(11, vgenIndex);
+    EXPECT_EQ(13, outputIndex);
     constantValue = 0.0f;
-    vgenIndex = -1;
-    outputIndex = -2;
     EXPECT_FALSE(pickAndMix.getInputConstantValue(1, constantValue));
     EXPECT_EQ(0.0f, constantValue);
     EXPECT_TRUE(pickAndMix.getInputVGenIndex(1, vgenIndex, outputIndex));
     EXPECT_EQ(14, vgenIndex);
     EXPECT_EQ(7, outputIndex);
     constantValue = 0.0f;
-    vgenIndex = -1;
-    outputIndex = -2;
+    vgenIndex = 15;
+    outputIndex = 18;
     EXPECT_TRUE(pickAndMix.getInputConstantValue(2, constantValue));
     EXPECT_EQ(12224.3f, constantValue);
     EXPECT_FALSE(pickAndMix.getInputVGenIndex(2, vgenIndex, outputIndex));
-    EXPECT_EQ(-1, vgenIndex);
-    EXPECT_EQ(-2, outputIndex);
+    EXPECT_EQ(15, vgenIndex);
+    EXPECT_EQ(18, outputIndex);
     EXPECT_TRUE(pickAndMix.validate());
 }
 

--- a/src/comp/Async.cpp
+++ b/src/comp/Async.cpp
@@ -31,7 +31,7 @@ Async::~Async() { stop(); }
 void Async::run(size_t numberOfWorkerThreads) {
     size_t workers = std::max(static_cast<size_t>(1), numberOfWorkerThreads);
     spdlog::info("Async starting {} worker threads.", workers);
-    for (auto i = 0; i < workers; ++i) {
+    for (size_t i = 0; i < workers; ++i) {
         std::string threadName = fmt::format("async_{}", i);
         m_workerThreads.emplace_back(std::thread(&Async::workerThreadMain, this, threadName));
     }

--- a/src/comp/Async.cpp
+++ b/src/comp/Async.cpp
@@ -29,7 +29,7 @@ Async::Async(std::shared_ptr<base::Archetypes> archetypes, std::shared_ptr<Compo
 Async::~Async() { stop(); }
 
 void Async::run(size_t numberOfWorkerThreads) {
-    size_t workers = std::max(1ull, numberOfWorkerThreads);
+    size_t workers = std::max(static_cast<size_t>(1), numberOfWorkerThreads);
     spdlog::info("Async starting {} worker threads.", workers);
     for (size_t i = 0; i < workers; ++i) {
         std::string threadName = fmt::format("async_{}", i);

--- a/src/comp/Async.cpp
+++ b/src/comp/Async.cpp
@@ -29,7 +29,7 @@ Async::Async(std::shared_ptr<base::Archetypes> archetypes, std::shared_ptr<Compo
 Async::~Async() { stop(); }
 
 void Async::run(size_t numberOfWorkerThreads) {
-    size_t workers = std::max(static_cast<size_t>(1), numberOfWorkerThreads);
+    size_t workers = std::max(1ull, numberOfWorkerThreads);
     spdlog::info("Async starting {} worker threads.", workers);
     for (size_t i = 0; i < workers; ++i) {
         std::string threadName = fmt::format("async_{}", i);
@@ -63,7 +63,7 @@ void Async::stop() {
     }
 }
 
-void Async::vgenLoadDirectory(fs::path path, std::function<void(int)> completion) {
+void Async::vgenLoadDirectory(fs::path path, std::function<void(size_t)> completion) {
     {
         std::lock_guard<std::mutex> lock(m_jobQueueMutex);
         m_jobQueue.emplace_back([this, path, completion]() { asyncVGenLoadDirectory(path, completion); });
@@ -71,7 +71,7 @@ void Async::vgenLoadDirectory(fs::path path, std::function<void(int)> completion
     m_jobQueueCondition.notify_one();
 }
 
-void Async::scinthDefLoadDirectory(fs::path path, std::function<void(int)> completion) {
+void Async::scinthDefLoadDirectory(fs::path path, std::function<void(size_t)> completion) {
     {
         std::lock_guard<std::mutex> lock(m_jobQueueMutex);
         m_jobQueue.emplace_back([this, path, completion]() { asyncScinthDefLoadDirectory(path, completion); });
@@ -79,7 +79,7 @@ void Async::scinthDefLoadDirectory(fs::path path, std::function<void(int)> compl
     m_jobQueueCondition.notify_one();
 }
 
-void Async::scinthDefLoadFile(fs::path path, std::function<void(int)> completion) {
+void Async::scinthDefLoadFile(fs::path path, std::function<void(size_t)> completion) {
     {
         std::lock_guard<std::mutex> lock(m_jobQueueMutex);
         m_jobQueue.emplace_back([this, path, completion]() { asyncScinthDefLoadFile(path, completion); });
@@ -87,7 +87,7 @@ void Async::scinthDefLoadFile(fs::path path, std::function<void(int)> completion
     m_jobQueueCondition.notify_one();
 }
 
-void Async::scinthDefParseString(std::string yaml, std::function<void(int)> completion) {
+void Async::scinthDefParseString(std::string yaml, std::function<void(size_t)> completion) {
     {
         std::lock_guard<std::mutex> lock(m_jobQueueMutex);
         m_jobQueue.emplace_back([this, yaml, completion]() { asyncScinthDefParseString(yaml, completion); });
@@ -238,15 +238,15 @@ void Async::syncThreadMain() {
     spdlog::debug("Async sync watcher thread exiting.");
 }
 
-void Async::asyncVGenLoadDirectory(fs::path path, std::function<void(int)> completion) {
+void Async::asyncVGenLoadDirectory(fs::path path, std::function<void(size_t)> completion) {
     if (!fs::exists(path) || !fs::is_directory(path)) {
         spdlog::error("nonexistent or not directory path {} for VGens.", path.string());
-        completion(-1);
+        completion(0);
         return;
     }
 
     spdlog::debug("Parsing yaml files in {} for AbstractVGens.", path.string());
-    auto parseCount = 0;
+    size_t parseCount = 0;
     for (auto entry : fs::directory_iterator(path)) {
         auto p = entry.path();
         if (fs::is_regular_file(p) && p.extension() == ".yaml") {
@@ -258,15 +258,15 @@ void Async::asyncVGenLoadDirectory(fs::path path, std::function<void(int)> compl
     completion(parseCount);
 }
 
-void Async::asyncScinthDefLoadDirectory(fs::path path, std::function<void(int)> completion) {
+void Async::asyncScinthDefLoadDirectory(fs::path path, std::function<void(size_t)> completion) {
     if (!fs::exists(path) || !fs::is_directory(path)) {
         spdlog::error("nonexistent or not directory path '{}' for ScinthDefs.", path.string());
-        completion(-1);
+        completion(0);
         return;
     }
 
     spdlog::debug("Parsing yaml files in directory {} for ScinthDefs.", path.string());
-    auto parseCount = 0;
+    size_t parseCount = 0;
     for (auto entry : fs::directory_iterator(path)) {
         auto p = entry.path();
         if (fs::is_regular_file(p) && p.extension() == ".yaml") {
@@ -284,15 +284,15 @@ void Async::asyncScinthDefLoadDirectory(fs::path path, std::function<void(int)> 
     completion(parseCount);
 }
 
-void Async::asyncScinthDefLoadFile(fs::path path, std::function<void(int)> completion) {
+void Async::asyncScinthDefLoadFile(fs::path path, std::function<void(size_t)> completion) {
     if (!fs::exists(path) || !fs::is_regular_file(path)) {
         spdlog::error("nonexistent or nonfile path '{}' for ScinthDefs.", path.string());
-        completion(-1);
+        completion(0);
         return;
     }
     spdlog::debug("Loading ScinthDefs from file {}.", path.string());
     std::vector<std::shared_ptr<const base::AbstractScinthDef>> scinthDefs = m_archetypes->loadFromFile(path.string());
-    auto parseCount = 0;
+    size_t parseCount = 0;
     for (auto scinthDef : scinthDefs) {
         if (m_compositor->buildScinthDef(scinthDef)) {
             ++parseCount;
@@ -302,7 +302,7 @@ void Async::asyncScinthDefLoadFile(fs::path path, std::function<void(int)> compl
     completion(parseCount);
 }
 
-void Async::asyncScinthDefParseString(std::string yaml, std::function<void(int)> completion) {
+void Async::asyncScinthDefParseString(std::string yaml, std::function<void(size_t)> completion) {
     std::vector<std::shared_ptr<const base::AbstractScinthDef>> scinthDefs = m_archetypes->parseFromString(yaml);
     for (auto scinthDef : scinthDefs) {
         m_compositor->buildScinthDef(scinthDef);

--- a/src/comp/Async.hpp
+++ b/src/comp/Async.hpp
@@ -62,7 +62,7 @@ public:
      * \param completion The function to call on completion of loading. The completion argument is the number of valid
      *        VGens loaded.
      */
-    void vgenLoadDirectory(fs::path path, std::function<void(int)> completion);
+    void vgenLoadDirectory(fs::path path, std::function<void(size_t)> completion);
 
     /*! Async load all ScinthDef yaml files at path.
      *
@@ -70,7 +70,7 @@ public:
      * \param completion The function to call on completion of loading. The completion argument is the number of valid
      *        ScinthDefs loaded.
      */
-    void scinthDefLoadDirectory(fs::path path, std::function<void(int)> completion);
+    void scinthDefLoadDirectory(fs::path path, std::function<void(size_t)> completion);
 
     /*! Async load ScinthDefs from a file.
      *
@@ -78,7 +78,7 @@ public:
      * \param completion The function to call on completion of loading. The completion argument is the number of valid
      *        ScinthDefs loaded.
      */
-    void scinthDefLoadFile(fs::path path, std::function<void(int)> completion);
+    void scinthDefLoadFile(fs::path path, std::function<void(size_t)> completion);
 
     /*! Async parse a ScinthDef yaml string.
      *
@@ -86,7 +86,7 @@ public:
      * \param completion The function to call on completion of parsing. The completion argument is the number of valid
      *        ScinthDefs parsed.
      */
-    void scinthDefParseString(std::string yaml, std::function<void(int)> completion);
+    void scinthDefParseString(std::string yaml, std::function<void(size_t)> completion);
 
     /*! Puts on of the async worker threads to sleep for the provided number of seconds. Useful for testing.
      *
@@ -109,11 +109,11 @@ private:
     void workerThreadMain(std::string threadName);
     void syncThreadMain();
 
-    void asyncVGenLoadDirectory(fs::path path, std::function<void(int)> completion);
+    void asyncVGenLoadDirectory(fs::path path, std::function<void(size_t)> completion);
 
-    void asyncScinthDefLoadDirectory(fs::path path, std::function<void(int)> completion);
-    void asyncScinthDefLoadFile(fs::path path, std::function<void(int)> completion);
-    void asyncScinthDefParseString(std::string yaml, std::function<void(int)> completion);
+    void asyncScinthDefLoadDirectory(fs::path path, std::function<void(size_t)> completion);
+    void asyncScinthDefLoadFile(fs::path path, std::function<void(size_t)> completion);
+    void asyncScinthDefParseString(std::string yaml, std::function<void(size_t)> completion);
 
     void asyncSleepFor(int seconds, std::function<void()> completion);
 

--- a/src/comp/AudioStager.cpp
+++ b/src/comp/AudioStager.cpp
@@ -16,7 +16,7 @@ AudioStager::~AudioStager() {}
 
 bool AudioStager::createBuffers(std::shared_ptr<vk::Device> device) {
     // TODO: fix hard-coded assumptions about 60Hz sample rate and stereo channels.
-    m_bufferFrameSize = m_ingress->sampleRate() / 60;
+    m_bufferFrameSize = static_cast<unsigned long>(m_ingress->sampleRate() / 60.0);
     m_buffer.reset(new vk::HostBuffer(device, vk::Buffer::Kind::kStaging, m_bufferFrameSize * 8));
     if (!m_buffer->create()) {
         spdlog::error("AudioStager failed to create HostBuffer of {} bytes", m_bufferFrameSize * 8);
@@ -42,9 +42,9 @@ void AudioStager::destroy() {
 
 void AudioStager::stageAudio(std::shared_ptr<StageManager> stageManager) {
     // Drop samples greater than two buffer sizes.
-    auto framesAvailable = m_ingress->availableFrames();
+    unsigned long framesAvailable = m_ingress->availableFrames();
     if (framesAvailable > 2 * m_bufferFrameSize) {
-        auto dropSize = framesAvailable - (2 * m_bufferFrameSize);
+        unsigned long dropSize = framesAvailable - (2 * m_bufferFrameSize);
         m_ingress->dropSamples(dropSize);
     }
     if (framesAvailable > m_bufferFrameSize) {

--- a/src/comp/AudioStager.hpp
+++ b/src/comp/AudioStager.hpp
@@ -34,7 +34,7 @@ public:
 
 private:
     std::shared_ptr<audio::Ingress> m_ingress;
-    size_t m_bufferFrameSize;
+    unsigned long m_bufferFrameSize;
     std::shared_ptr<vk::HostBuffer> m_buffer;
     std::shared_ptr<vk::DeviceImage> m_image;
 };

--- a/src/comp/AudioStager.hpp
+++ b/src/comp/AudioStager.hpp
@@ -34,7 +34,7 @@ public:
 
 private:
     std::shared_ptr<audio::Ingress> m_ingress;
-    int m_bufferFrameSize;
+    size_t m_bufferFrameSize;
     std::shared_ptr<vk::HostBuffer> m_buffer;
     std::shared_ptr<vk::DeviceImage> m_image;
 };

--- a/src/comp/Canvas.cpp
+++ b/src/comp/Canvas.cpp
@@ -71,7 +71,7 @@ bool Canvas::create(const std::vector<std::shared_ptr<vk::Image>>& images) {
 
     // Lastly create the Framebuffers, one per image.
     m_framebuffers.resize(m_numberOfImages);
-    for (auto i = 0; i < m_numberOfImages; ++i) {
+    for (size_t i = 0; i < m_numberOfImages; ++i) {
         VkImageView attachments[] = { images[i]->view() };
 
         VkFramebufferCreateInfo framebufferInfo = {};

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -308,7 +308,7 @@ void Compositor::destroy() {
     }
 }
 
-int Compositor::numberOfRunningScinths() {
+size_t Compositor::numberOfRunningScinths() {
     std::lock_guard<std::mutex> lock(m_scinthMutex);
     return m_scinths.size();
 }
@@ -317,7 +317,7 @@ bool Compositor::getGraphicsMemoryBudget(size_t& bytesUsedOut, size_t& bytesBudg
     return m_device->getGraphicsMemoryBudget(bytesUsedOut, bytesBudgetOut);
 }
 
-void Compositor::stageImage(int imageID, int width, int height, std::shared_ptr<vk::HostBuffer> imageBuffer,
+void Compositor::stageImage(int imageID, uint32_t width, uint32_t height, std::shared_ptr<vk::HostBuffer> imageBuffer,
                             std::function<void()> completion) {
     std::shared_ptr<vk::DeviceImage> targetImage(new vk::DeviceImage(m_device, VK_FORMAT_R8G8B8A8_UNORM));
     if (!targetImage->create(width, height)) {
@@ -341,7 +341,7 @@ void Compositor::stageImage(int imageID, int width, int height, std::shared_ptr<
     }
 }
 
-bool Compositor::queryImage(int imageID, int& sizeOut, int& widthOut, int& heightOut) {
+bool Compositor::queryImage(int imageID, size_t& sizeOut, uint32_t& widthOut, uint32_t& heightOut) {
     std::shared_ptr<vk::DeviceImage> image = m_imageMap->getImage(imageID);
     if (!image) {
         return false;
@@ -395,7 +395,8 @@ bool Compositor::rebuildCommandBuffer() {
             for (auto command : m_computeSecondary) {
                 commandBuffers.emplace_back(command->buffer(i));
             }
-            vkCmdExecuteCommands(m_computePrimary->buffer(i), commandBuffers.size(), commandBuffers.data());
+            vkCmdExecuteCommands(m_computePrimary->buffer(i), static_cast<uint32_t>(commandBuffers.size()),
+                commandBuffers.data());
 
             if (vkEndCommandBuffer(m_computePrimary->buffer(i)) != VK_SUCCESS) {
                 spdlog::error("Compositor failed ending primary compute command buffer.");
@@ -450,7 +451,8 @@ bool Compositor::rebuildCommandBuffer() {
             for (auto command : m_drawSecondary) {
                 commandBuffers.emplace_back(command->buffer(i));
             }
-            vkCmdExecuteCommands(m_drawPrimary->buffer(i), commandBuffers.size(), commandBuffers.data());
+            vkCmdExecuteCommands(m_drawPrimary->buffer(i), static_cast<uint32_t>(commandBuffers.size()),
+                commandBuffers.data());
         } else {
             vkCmdBeginRenderPass(m_drawPrimary->buffer(i), &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
         }

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -396,7 +396,7 @@ bool Compositor::rebuildCommandBuffer() {
                 commandBuffers.emplace_back(command->buffer(i));
             }
             vkCmdExecuteCommands(m_computePrimary->buffer(i), static_cast<uint32_t>(commandBuffers.size()),
-                commandBuffers.data());
+                                 commandBuffers.data());
 
             if (vkEndCommandBuffer(m_computePrimary->buffer(i)) != VK_SUCCESS) {
                 spdlog::error("Compositor failed ending primary compute command buffer.");
@@ -452,7 +452,7 @@ bool Compositor::rebuildCommandBuffer() {
                 commandBuffers.emplace_back(command->buffer(i));
             }
             vkCmdExecuteCommands(m_drawPrimary->buffer(i), static_cast<uint32_t>(commandBuffers.size()),
-                commandBuffers.data());
+                                 commandBuffers.data());
         } else {
             vkCmdBeginRenderPass(m_drawPrimary->buffer(i), &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
         }

--- a/src/comp/Compositor.cpp
+++ b/src/comp/Compositor.cpp
@@ -380,7 +380,7 @@ bool Compositor::rebuildCommandBuffer() {
         spdlog::debug("rebuilding Compositor compute command buffer with {} secondary command buffers",
                       m_computeSecondary.size());
 
-        for (auto i = 0; i < m_canvas->numberOfImages(); ++i) {
+        for (size_t i = 0; i < m_canvas->numberOfImages(); ++i) {
             VkCommandBufferBeginInfo beginInfo = {};
             beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
             beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
@@ -422,7 +422,7 @@ bool Compositor::rebuildCommandBuffer() {
     spdlog::debug("rebuilding Compositor draw command buffer with {} secondary command buffers",
                   m_drawSecondary.size());
 
-    for (auto i = 0; i < m_canvas->numberOfImages(); ++i) {
+    for (size_t i = 0; i < m_canvas->numberOfImages(); ++i) {
         VkCommandBufferBeginInfo beginInfo = {};
         beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
         beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;

--- a/src/comp/Compositor.hpp
+++ b/src/comp/Compositor.hpp
@@ -129,7 +129,7 @@ public:
 
     void setClearColor(glm::vec3 color) { m_clearColor = color; }
 
-    int numberOfRunningScinths();
+    size_t numberOfRunningScinths();
 
     /*! Relayed from the graphics device, convenience method.
      */
@@ -143,7 +143,7 @@ public:
      * \param imageBuffer The bytes of the image in RGBA format.
      * \param completion A function to call once the image has been staged.
      */
-    void stageImage(int imageID, int width, int height, std::shared_ptr<vk::HostBuffer> imageBuffer,
+    void stageImage(int imageID, uint32_t width, uint32_t height, std::shared_ptr<vk::HostBuffer> imageBuffer,
                     std::function<void()> completion);
 
     /*! Returns basic information about a compositor image associated with imageID, if it exists.
@@ -154,7 +154,7 @@ public:
      * \param heightOut Will store the height of the image buffer in pixels
      * \return True if the image was found and the output values have been written, false otherwise.
      */
-    bool queryImage(int imageID, int& sizeOut, int& widthOut, int& heightOut);
+    bool queryImage(int imageID, size_t& sizeOut, uint32_t& widthOut, uint32_t& heightOut);
 
     /*! Adds an audio Ingress object for provision of audio data to the GPU.
      *

--- a/src/comp/FrameTimer.cpp
+++ b/src/comp/FrameTimer.cpp
@@ -55,7 +55,7 @@ double FrameTimer::elapsedTime() {
     return std::chrono::duration<double, std::chrono::seconds::period>(m_lastFrameTime - m_startTime).count();
 }
 
-void FrameTimer::getStats(int& targetFrameRateOut, double& meanFrameRateOut, size_t lateFramesOut) const {
+void FrameTimer::getStats(int& targetFrameRateOut, double& meanFrameRateOut, size_t& lateFramesOut) const {
     std::lock_guard<std::mutex> lock(m_statsMutex);
     targetFrameRateOut = m_targetFrameRate;
     meanFrameRateOut = m_meanFrameRate;

--- a/src/comp/FrameTimer.hpp
+++ b/src/comp/FrameTimer.hpp
@@ -32,7 +32,7 @@ public:
 
     /*! Returns most recent statistics about timing. Thread-safe, callable from anywhere.
      */
-    void getStats(int& targetFrameRateOut, double& meanFrameRateOut, size_t lateFramesOut) const;
+    void getStats(int& targetFrameRateOut, double& meanFrameRateOut, size_t& lateFramesOut) const;
 
 private:
     void updateStats(double meanPeriod);

--- a/src/comp/ImageMap.cpp
+++ b/src/comp/ImageMap.cpp
@@ -4,12 +4,12 @@
 
 namespace scin { namespace comp {
 
-void ImageMap::addImage(int imageID, std::shared_ptr<vk::DeviceImage> image) {
+void ImageMap::addImage(size_t imageID, std::shared_ptr<vk::DeviceImage> image) {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_images[imageID] = image;
 }
 
-std::shared_ptr<vk::DeviceImage> ImageMap::getImage(int imageID) {
+std::shared_ptr<vk::DeviceImage> ImageMap::getImage(size_t imageID) {
     std::lock_guard<std::mutex> lock(m_mutex);
     std::shared_ptr<vk::DeviceImage> image;
     auto it = m_images.find(imageID);
@@ -19,7 +19,7 @@ std::shared_ptr<vk::DeviceImage> ImageMap::getImage(int imageID) {
     return image;
 }
 
-void ImageMap::removeImage(int imageID) {
+void ImageMap::removeImage(size_t imageID) {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_images.erase(imageID);
 }

--- a/src/comp/ImageMap.hpp
+++ b/src/comp/ImageMap.hpp
@@ -19,9 +19,9 @@ public:
     ~ImageMap() = default;
 
     // Will overwrite any existing image associated with imageID.
-    void addImage(int imageID, std::shared_ptr<vk::DeviceImage> image);
-    std::shared_ptr<vk::DeviceImage> getImage(int imageID);
-    void removeImage(int imageID);
+    void addImage(size_t imageID, std::shared_ptr<vk::DeviceImage> image);
+    std::shared_ptr<vk::DeviceImage> getImage(size_t imageID);
+    void removeImage(size_t imageID);
 
     // Returns a 1x1 transparent black image.
     std::shared_ptr<vk::DeviceImage> getEmptyImage() const { return m_emptyImage; }
@@ -30,7 +30,7 @@ public:
 
 private:
     std::mutex m_mutex;
-    std::unordered_map<int, std::shared_ptr<vk::DeviceImage>> m_images;
+    std::unordered_map<size_t, std::shared_ptr<vk::DeviceImage>> m_images;
     std::shared_ptr<vk::DeviceImage> m_emptyImage;
 };
 

--- a/src/comp/Offscreen.cpp
+++ b/src/comp/Offscreen.cpp
@@ -210,7 +210,7 @@ void Offscreen::threadMain(std::shared_ptr<Compositor> compositor) {
 
     double time = 0.0;
     size_t frameNumber = 0;
-    size_t frameIndex = 0;
+    uint32_t frameIndex = 0;
 
     m_computeCommands.resize(m_numberOfImages);
     m_drawCommands.resize(m_numberOfImages);
@@ -365,7 +365,7 @@ void Offscreen::threadMain(std::shared_ptr<Compositor> compositor) {
 
         m_renderSync->resetFrame(frameIndex);
 
-        drawSubmitInfo.commandBufferCount = drawCommandBuffers.size();
+        drawSubmitInfo.commandBufferCount = static_cast<uint32_t>(drawCommandBuffers.size());
         drawSubmitInfo.pCommandBuffers = drawCommandBuffers.data();
 
         if (vkQueueSubmit(m_device->graphicsQueue(), 1, &drawSubmitInfo, m_renderSync->frameRendering(frameIndex))
@@ -383,7 +383,7 @@ void Offscreen::threadMain(std::shared_ptr<Compositor> compositor) {
 
         time += deltaTime;
         ++frameNumber;
-        frameIndex = frameNumber % m_numberOfImages;
+        frameIndex = static_cast<uint32_t>(frameNumber % m_numberOfImages);
     }
 
     vkDeviceWaitIdle(m_device->get());

--- a/src/comp/Offscreen.cpp
+++ b/src/comp/Offscreen.cpp
@@ -65,7 +65,7 @@ bool Offscreen::create(size_t numberOfImages) {
 
     // Prepare for readback by allocating GPU memory for readback images, checking for efficient copy operations from
     // the framebuffer to those readback images, and building command buffers to do the actual readback.
-    for (auto i = 0; i < m_numberOfImages; ++i) {
+    for (size_t i = 0; i < m_numberOfImages; ++i) {
         std::shared_ptr<vk::HostImage> image(new vk::HostImage(m_device));
         if (!image->createWithStride(m_width, m_height, m_bufferPool->stride())) {
             spdlog::error("Offscreen failed to create {} readback images.", m_numberOfImages);
@@ -84,7 +84,7 @@ bool Offscreen::create(size_t numberOfImages) {
         spdlog::error("Offscreen failed to create command buffers.");
         return false;
     }
-    for (auto i = 0; i < m_numberOfImages; ++i) {
+    for (size_t i = 0; i < m_numberOfImages; ++i) {
         if (!writeCopyCommands(m_readbackCommands, i, m_framebuffer->image(i), m_readbackImages[i]->get())) {
             spdlog::error("Offscreen failed to create readback command buffers.");
             return false;
@@ -99,14 +99,14 @@ bool Offscreen::supportSwapchain(std::shared_ptr<Swapchain> swapchain, std::shar
     m_swapRenderSync = swapRenderSync;
 
     // Build the transfer from framebuffer to swapchain images command buffers.
-    for (auto i = 0; i < m_numberOfImages; ++i) {
+    for (size_t i = 0; i < m_numberOfImages; ++i) {
         std::shared_ptr<vk::CommandBuffer> buffer(new vk::CommandBuffer(m_device, m_commandPool));
         if (!buffer->create(swapchain->numberOfImages(), true)) {
             spdlog::error("Offscreen failed creating swapchain source blit command buffers.");
             return false;
         }
         // The jth command buffer will blit from the ith framebuffer image to the jth swapchain image.
-        for (auto j = 0; j < swapchain->numberOfImages(); ++j) {
+        for (size_t j = 0; j < swapchain->numberOfImages(); ++j) {
             if (!writeBlitCommands(buffer, j, m_framebuffer->image(i), swapchain->images()[j]->get(),
                                    VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)) {
                 spdlog::error("Offscreen failed writing swapchain source blit command buffers.");
@@ -214,7 +214,7 @@ void Offscreen::threadMain(std::shared_ptr<Compositor> compositor) {
 
     m_computeCommands.resize(m_numberOfImages);
     m_drawCommands.resize(m_numberOfImages);
-    for (auto i = 0; i < m_numberOfImages; ++i) {
+    for (size_t i = 0; i < m_numberOfImages; ++i) {
         m_pendingSwapchainBlits.push_back(-1);
     }
     m_pendingEncodes.resize(m_numberOfImages);

--- a/src/comp/Pipeline.cpp
+++ b/src/comp/Pipeline.cpp
@@ -32,7 +32,7 @@ bool Pipeline::create(const base::Manifest& vertexManifest, const base::Shape* s
     std::vector<VkVertexInputAttributeDescription> vertexAttributes(vertexManifest.numberOfElements());
     for (size_t i = 0; i < vertexManifest.numberOfElements(); ++i) {
         vertexAttributes[i].binding = 0;
-        vertexAttributes[i].location = i;
+        vertexAttributes[i].location = static_cast<uint32_t>(i);
         VkFormat format;
         switch (vertexManifest.typeForElement(i)) {
         case base::Manifest::ElementType::kFloat:
@@ -63,7 +63,7 @@ bool Pipeline::create(const base::Manifest& vertexManifest, const base::Shape* s
     vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
     vertexInputInfo.vertexBindingDescriptionCount = 1;
     vertexInputInfo.pVertexBindingDescriptions = &vertexBindingDescription;
-    vertexInputInfo.vertexAttributeDescriptionCount = vertexAttributes.size();
+    vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(vertexAttributes.size());
     vertexInputInfo.pVertexAttributeDescriptions = vertexAttributes.data();
 
     // Input Assembly
@@ -173,7 +173,7 @@ bool Pipeline::create(const base::Manifest& vertexManifest, const base::Shape* s
     if (pushConstantBlockSize) {
         pushConstantRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_VERTEX_BIT;
         pushConstantRange.offset = 0;
-        pushConstantRange.size = pushConstantBlockSize;
+        pushConstantRange.size = static_cast<uint32_t>(pushConstantBlockSize);
         pipelineLayoutInfo.pushConstantRangeCount = 1;
         pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
     } else {
@@ -254,7 +254,7 @@ bool Pipeline::createCompute(std::shared_ptr<vk::Shader> computeShader, VkDescri
     if (pushConstantBlockSize) {
         pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
         pushConstantRange.offset = 0;
-        pushConstantRange.size = pushConstantBlockSize;
+        pushConstantRange.size = static_cast<uint32_t>(pushConstantBlockSize);
         pipelineLayoutInfo.pushConstantRangeCount = 1;
         pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
     } else {

--- a/src/comp/Pipeline.cpp
+++ b/src/comp/Pipeline.cpp
@@ -30,7 +30,7 @@ bool Pipeline::create(const base::Manifest& vertexManifest, const base::Shape* s
     vertexBindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
     std::vector<VkVertexInputAttributeDescription> vertexAttributes(vertexManifest.numberOfElements());
-    for (auto i = 0; i < vertexManifest.numberOfElements(); ++i) {
+    for (size_t i = 0; i < vertexManifest.numberOfElements(); ++i) {
         vertexAttributes[i].binding = 0;
         vertexAttributes[i].location = i;
         VkFormat format;
@@ -50,6 +50,10 @@ bool Pipeline::create(const base::Manifest& vertexManifest, const base::Shape* s
         case base::Manifest::ElementType::kVec4:
             format = VK_FORMAT_R32G32B32A32_SFLOAT;
             break;
+
+        default:
+            spdlog::error("unsupported vertex format in Pipeline creation");
+            return false;
         }
         vertexAttributes[i].format = format;
         vertexAttributes[i].offset = vertexManifest.offsetForElement(i);

--- a/src/comp/RenderSync.cpp
+++ b/src/comp/RenderSync.cpp
@@ -22,7 +22,7 @@ bool RenderSync::create(size_t inFlightFrames, bool makeSwapchainSemaphore) {
     m_renderFinished.resize(inFlightFrames);
     m_frameRendering.resize(inFlightFrames);
 
-    for (auto i = 0; i < inFlightFrames; ++i) {
+    for (size_t i = 0; i < inFlightFrames; ++i) {
         VkSemaphoreCreateInfo semaphoreInfo = {};
         semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
         if (makeSwapchainSemaphore) {
@@ -54,22 +54,22 @@ bool RenderSync::create(size_t inFlightFrames, bool makeSwapchainSemaphore) {
 }
 
 void RenderSync::destroy() {
-    for (auto i = 0; i < m_imageAvailable.size(); ++i) {
+    for (size_t i = 0; i < m_imageAvailable.size(); ++i) {
         vkDestroySemaphore(m_device->get(), m_imageAvailable[i], nullptr);
     }
     m_imageAvailable.clear();
 
-    for (auto i = 0; i < m_computeFinished.size(); ++i) {
+    for (size_t i = 0; i < m_computeFinished.size(); ++i) {
         vkDestroySemaphore(m_device->get(), m_computeFinished[i], nullptr);
     }
     m_computeFinished.clear();
 
-    for (auto i = 0; i < m_renderFinished.size(); ++i) {
+    for (size_t i = 0; i < m_renderFinished.size(); ++i) {
         vkDestroySemaphore(m_device->get(), m_renderFinished[i], nullptr);
     }
     m_renderFinished.clear();
 
-    for (auto i = 0; i < m_frameRendering.size(); ++i) {
+    for (size_t i = 0; i < m_frameRendering.size(); ++i) {
         vkDestroyFence(m_device->get(), m_frameRendering[i], nullptr);
     }
     m_frameRendering.clear();

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -106,8 +106,8 @@ bool Scinth::prepareFrame(size_t imageIndex, double frameTime) {
 }
 
 void Scinth::setParameterByName(const std::string& name, float value) {
-    int index = m_scinthDef->abstract()->indexForParameterName(name);
-    if (index >= 0) {
+    size_t index = 0;
+    if (m_scinthDef->abstract()->indexForParameterName(name, index)) {
         m_parameterValues[index] = value;
         m_commandBuffersDirty = true;
     } else {

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -133,7 +133,7 @@ bool Scinth::allocateDescriptors() {
     if (uniformSize) {
         VkDescriptorPoolSize uniformPoolSize = {};
         uniformPoolSize.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        uniformPoolSize.descriptorCount = numberOfImages;
+        uniformPoolSize.descriptorCount = static_cast<uint32_t>(numberOfImages);
         poolSizes.emplace_back(uniformPoolSize);
 
         for (size_t i = 0; i < numberOfImages; ++i) {
@@ -152,7 +152,7 @@ bool Scinth::allocateDescriptors() {
     if (totalSamplers) {
         VkDescriptorPoolSize samplerPoolSize = {};
         samplerPoolSize.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        samplerPoolSize.descriptorCount = numberOfImages * totalSamplers;
+        samplerPoolSize.descriptorCount = static_cast<uint32_t>(numberOfImages * totalSamplers);
         poolSizes.emplace_back(samplerPoolSize);
     }
 
@@ -160,7 +160,7 @@ bool Scinth::allocateDescriptors() {
     if (computeBufferSize) {
         VkDescriptorPoolSize bufferPoolSize = {};
         bufferPoolSize.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        bufferPoolSize.descriptorCount = numberOfImages;
+        bufferPoolSize.descriptorCount = static_cast<uint32_t>(numberOfImages);
         poolSizes.emplace_back(bufferPoolSize);
 
         for (size_t i = 0; i < numberOfImages; ++i) {
@@ -177,9 +177,9 @@ bool Scinth::allocateDescriptors() {
 
     VkDescriptorPoolCreateInfo poolInfo = {};
     poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.poolSizeCount = poolSizes.size();
+    poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
     poolInfo.pPoolSizes = poolSizes.data();
-    poolInfo.maxSets = numberOfImages;
+    poolInfo.maxSets = static_cast<uint32_t>(numberOfImages);
     if (vkCreateDescriptorPool(m_device->get(), &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS) {
         spdlog::error("Scinth {} failed to create Vulkan descriptor pool.", m_nodeID);
         return false;
@@ -189,7 +189,7 @@ bool Scinth::allocateDescriptors() {
     VkDescriptorSetAllocateInfo allocInfo = {};
     allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
     allocInfo.descriptorPool = m_descriptorPool;
-    allocInfo.descriptorSetCount = numberOfImages;
+    allocInfo.descriptorSetCount = static_cast<uint32_t>(numberOfImages);
     allocInfo.pSetLayouts = layouts.data();
     m_descriptorSets.resize(numberOfImages);
     if (vkAllocateDescriptorSets(m_device->get(), &allocInfo, m_descriptorSets.data()) != VK_SUCCESS) {

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -312,8 +312,8 @@ bool Scinth::allocateDescriptors() {
             ++binding;
         }
 
-        vkUpdateDescriptorSets(m_device->get(), static_cast<uint32_t>(descriptorWrites.size()),
-            descriptorWrites.data(), 0, nullptr);
+        vkUpdateDescriptorSets(m_device->get(), static_cast<uint32_t>(descriptorWrites.size()), descriptorWrites.data(),
+                               0, nullptr);
     }
 
     return true;
@@ -371,8 +371,8 @@ bool Scinth::updateDescriptors() {
             descriptorWrites.emplace_back(imageWrite);
         }
 
-        vkUpdateDescriptorSets(m_device->get(), static_cast<uint32_t>(descriptorWrites.size()),
-            descriptorWrites.data(), 0, nullptr);
+        vkUpdateDescriptorSets(m_device->get(), static_cast<uint32_t>(descriptorWrites.size()), descriptorWrites.data(),
+                               0, nullptr);
     }
 
     return true;
@@ -418,10 +418,9 @@ bool Scinth::rebuildBuffers() {
 
             // Write parameters as push constants.
             if (m_numberOfParameters) {
-                vkCmdPushConstants(m_computeCommands->buffer(i), m_scinthDef->computePipeline()->layout(),
-                                   VK_SHADER_STAGE_COMPUTE_BIT, 0,
-                                   static_cast<uint32_t>(m_numberOfParameters * sizeof(float)),
-                                   m_parameterValues.get());
+                vkCmdPushConstants(
+                    m_computeCommands->buffer(i), m_scinthDef->computePipeline()->layout(), VK_SHADER_STAGE_COMPUTE_BIT,
+                    0, static_cast<uint32_t>(m_numberOfParameters * sizeof(float)), m_parameterValues.get());
             }
 
             // Bind compute pipeline.

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -256,8 +256,8 @@ bool Scinth::allocateDescriptors() {
         samplerIndex = 0;
         for (const auto pair : m_scinthDef->abstract()->drawParameterizedImages()) {
             // Look up default value of parameter using parameter index, provided as second value in the pair.
-            int parameterIndex = pair.second;
-            int imageID = static_cast<int>(m_scinthDef->abstract()->parameters()[parameterIndex].defaultValue());
+            size_t parameterIndex = pair.second;
+            size_t imageID = static_cast<int>(m_scinthDef->abstract()->parameters()[parameterIndex].defaultValue());
             std::shared_ptr<vk::DeviceImage> image = m_imageMap->getImage(imageID);
             std::shared_ptr<vk::Sampler> sampler = m_scinthDef->parameterizedSamplers()[samplerIndex];
             // We record these decisions on the first run through, for comparison against later parameter updates.
@@ -312,7 +312,8 @@ bool Scinth::allocateDescriptors() {
             ++binding;
         }
 
-        vkUpdateDescriptorSets(m_device->get(), descriptorWrites.size(), descriptorWrites.data(), 0, nullptr);
+        vkUpdateDescriptorSets(m_device->get(), static_cast<uint32_t>(descriptorWrites.size()),
+            descriptorWrites.data(), 0, nullptr);
     }
 
     return true;
@@ -320,10 +321,10 @@ bool Scinth::allocateDescriptors() {
 
 bool Scinth::updateDescriptors() {
     // This pair is sampler index, new image and we build it by running through parameter values and current bound ids.
-    std::vector<std::pair<int, std::shared_ptr<vk::DeviceImage>>> newBindings;
+    std::vector<std::pair<size_t, std::shared_ptr<vk::DeviceImage>>> newBindings;
     for (size_t i = 0; i < m_parameterizedImageIDs.size(); ++i) {
         size_t parameterIndex = m_parameterizedImageIDs[i].first;
-        int imageID = static_cast<int>(m_parameterValues[parameterIndex]);
+        size_t imageID = static_cast<size_t>(m_parameterValues[parameterIndex]);
         if (imageID != m_parameterizedImageIDs[i].second) {
             std::shared_ptr<vk::DeviceImage> image = m_imageMap->getImage(imageID);
             // Note image can be null, we'll use the empty image in the actual update.
@@ -340,7 +341,7 @@ bool Scinth::updateDescriptors() {
 
     // Compute index where parameterized images binding starts.
     int32_t bindingStart = m_scinthDef->abstract()->uniformManifest().sizeInBytes() ? 1 : 0;
-    bindingStart += m_scinthDef->abstract()->drawFixedImages().size();
+    bindingStart += static_cast<int32_t>(m_scinthDef->abstract()->drawFixedImages().size());
 
     for (size_t i = 0; i < m_scinthDef->canvas()->numberOfImages(); ++i) {
         std::vector<VkWriteDescriptorSet> descriptorWrites;
@@ -362,7 +363,7 @@ bool Scinth::updateDescriptors() {
             VkWriteDescriptorSet imageWrite = {};
             imageWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             imageWrite.dstSet = m_descriptorSets[i];
-            imageWrite.dstBinding = bindingStart + pair.first;
+            imageWrite.dstBinding = static_cast<uint32_t>(bindingStart + pair.first);
             imageWrite.dstArrayElement = 0;
             imageWrite.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             imageWrite.descriptorCount = 1;
@@ -370,7 +371,8 @@ bool Scinth::updateDescriptors() {
             descriptorWrites.emplace_back(imageWrite);
         }
 
-        vkUpdateDescriptorSets(m_device->get(), descriptorWrites.size(), descriptorWrites.data(), 0, nullptr);
+        vkUpdateDescriptorSets(m_device->get(), static_cast<uint32_t>(descriptorWrites.size()),
+            descriptorWrites.data(), 0, nullptr);
     }
 
     return true;
@@ -417,7 +419,8 @@ bool Scinth::rebuildBuffers() {
             // Write parameters as push constants.
             if (m_numberOfParameters) {
                 vkCmdPushConstants(m_computeCommands->buffer(i), m_scinthDef->computePipeline()->layout(),
-                                   VK_SHADER_STAGE_COMPUTE_BIT, 0, m_numberOfParameters * sizeof(float),
+                                   VK_SHADER_STAGE_COMPUTE_BIT, 0,
+                                   static_cast<uint32_t>(m_numberOfParameters * sizeof(float)),
                                    m_parameterValues.get());
             }
 
@@ -484,7 +487,7 @@ bool Scinth::rebuildBuffers() {
         if (m_numberOfParameters) {
             vkCmdPushConstants(m_drawCommands->buffer(i), m_scinthDef->drawPipeline()->layout(),
                                VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
-                               m_numberOfParameters * sizeof(float), m_parameterValues.get());
+                               static_cast<uint32_t>(m_numberOfParameters * sizeof(float)), m_parameterValues.get());
         }
 
         vkCmdBindPipeline(m_drawCommands->buffer(i), VK_PIPELINE_BIND_POINT_GRAPHICS,

--- a/src/comp/Scinth.hpp
+++ b/src/comp/Scinth.hpp
@@ -97,7 +97,7 @@ private:
     std::vector<std::shared_ptr<vk::HostBuffer>> m_uniformBuffers;
     std::vector<std::shared_ptr<vk::DeviceBuffer>> m_computeBuffers;
     // The parameter index and the currently bound image Ids for parameterized images.
-    std::vector<std::pair<int, int>> m_parameterizedImageIDs;
+    std::vector<std::pair<size_t, size_t>> m_parameterizedImageIDs;
     std::shared_ptr<vk::CommandBuffer> m_computeCommands;
     std::shared_ptr<vk::CommandBuffer> m_drawCommands;
     bool m_running;

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -152,7 +152,7 @@ bool ScinthDef::buildDescriptorLayout() {
     }
 
     auto totalSamplers = m_abstract->drawFixedImages().size() + m_abstract->drawParameterizedImages().size();
-    for (auto i = 0; i < totalSamplers; ++i) {
+    for (size_t i = 0; i < totalSamplers; ++i) {
         VkDescriptorSetLayoutBinding imageBinding = {};
         imageBinding.binding = bindings.size();
         imageBinding.descriptorCount = 1;

--- a/src/comp/ScinthDef.cpp
+++ b/src/comp/ScinthDef.cpp
@@ -143,7 +143,7 @@ bool ScinthDef::buildDescriptorLayout() {
     std::vector<VkDescriptorSetLayoutBinding> bindings;
     if (m_abstract->uniformManifest().sizeInBytes()) {
         VkDescriptorSetLayoutBinding uniformBinding = {};
-        uniformBinding.binding = bindings.size();
+        uniformBinding.binding = static_cast<uint32_t>(bindings.size());
         uniformBinding.descriptorCount = 1;
         uniformBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         uniformBinding.stageFlags =
@@ -154,7 +154,7 @@ bool ScinthDef::buildDescriptorLayout() {
     auto totalSamplers = m_abstract->drawFixedImages().size() + m_abstract->drawParameterizedImages().size();
     for (size_t i = 0; i < totalSamplers; ++i) {
         VkDescriptorSetLayoutBinding imageBinding = {};
-        imageBinding.binding = bindings.size();
+        imageBinding.binding = static_cast<uint32_t>(bindings.size());
         imageBinding.descriptorCount = 1;
         imageBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
         imageBinding.stageFlags =
@@ -164,7 +164,7 @@ bool ScinthDef::buildDescriptorLayout() {
 
     if (m_abstract->computeManifest().sizeInBytes()) {
         VkDescriptorSetLayoutBinding bufferBinding = {};
-        bufferBinding.binding = bindings.size();
+        bufferBinding.binding = static_cast<uint32_t>(bindings.size());
         bufferBinding.descriptorCount = 1;
         bufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         bufferBinding.stageFlags =
@@ -175,7 +175,7 @@ bool ScinthDef::buildDescriptorLayout() {
     if (bindings.size()) {
         VkDescriptorSetLayoutCreateInfo layoutInfo = {};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        layoutInfo.bindingCount = bindings.size();
+        layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
         layoutInfo.pBindings = bindings.data();
         if (vkCreateDescriptorSetLayout(m_device->get(), &layoutInfo, nullptr, &m_descriptorSetLayout) != VK_SUCCESS) {
             return false;

--- a/src/comp/ShaderCompiler.cpp
+++ b/src/comp/ShaderCompiler.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<vk::Shader> ShaderCompiler::compile(std::shared_ptr<vk::Device> 
     if (status == shaderc_compilation_status_success) {
         const char* spv_bytes = shaderc_result_get_bytes(result);
         size_t byte_size = shaderc_result_get_length(result);
-        shader.reset(new vk::Shader(kind, device, entryPoint));
+        shader.reset(new vk::Shader(device, entryPoint));
         if (!shader->create(spv_bytes, byte_size)) {
             spdlog::error("error creating shader from compiled source {}.", name);
             shader.reset(nullptr);

--- a/src/comp/ShaderCompiler.cpp
+++ b/src/comp/ShaderCompiler.cpp
@@ -46,6 +46,10 @@ std::unique_ptr<vk::Shader> ShaderCompiler::compile(std::shared_ptr<vk::Device> 
     case vk::Shader::kFragment:
         shaderKind = shaderc_fragment_shader;
         break;
+
+    default:
+        spdlog::error("Unknown kind of shader in ShaderCompiler");
+        return std::unique_ptr<vk::Shader>();
     }
 
     shaderc_compile_options_t options = shaderc_compile_options_initialize();

--- a/src/comp/StageManager.cpp
+++ b/src/comp/StageManager.cpp
@@ -168,8 +168,8 @@ bool StageManager::submitTransferCommands(VkQueue queue) {
     VkCommandBuffer commandBuffers[] = { wait.commands->buffer(0) };
     submitInfo.pCommandBuffers = commandBuffers;
 
-    if (vkQueueSubmit(m_device->graphicsQueue(), 1, &submitInfo, m_fences[wait.fenceIndex]) != VK_SUCCESS) {
-        spdlog::error("StageManager failed to submit transfer command buffer to graphics queue.");
+    if (vkQueueSubmit(queue, 1, &submitInfo, m_fences[wait.fenceIndex]) != VK_SUCCESS) {
+        spdlog::error("StageManager failed to submit transfer command buffer to provided queue.");
         return false;
     }
 

--- a/src/comp/StageManager.cpp
+++ b/src/comp/StageManager.cpp
@@ -28,7 +28,7 @@ bool StageManager::create(size_t numberOfImages) {
         return false;
     }
 
-    for (auto i = 0; i < numberOfImages; ++i) {
+    for (size_t i = 0; i < numberOfImages; ++i) {
         VkFenceCreateInfo fenceInfo = {};
         fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -34,9 +34,10 @@ namespace {
 static const char* kGargamelleURL = "https://ggml.scintillatorsynth.org/api/dump";
 
 void logReport(const crashpad::CrashReportDatabase::Report& report) {
-    tm* createTime = localtime(&report.creation_time);
+    struct tm createTime;
+    localtime_s(&createTime, &report.creation_time);
     std::array<char, 128> timeBuf;
-    strftime(timeBuf.data(), sizeof(timeBuf), "%a %d %b %H:%M:%S %Y", createTime);
+    strftime(timeBuf.data(), sizeof(timeBuf), "%a %d %b %H:%M:%S %Y", &createTime);
     spdlog::info("    id: {}, on: {}, uploaded: {}", report.uuid.ToString(), timeBuf.data(),
                  report.uploaded ? "yes" : "no");
 }
@@ -105,7 +106,7 @@ int CrashReporter::logCrashReports() {
         return -1;
     }
 
-    auto notUploaded = pendingReports.size();
+    int notUploaded = static_cast<int>(pendingReports.size());
     if (pendingReports.size() + completedReports.size()) {
         spdlog::info("Crash report database contains {} reports:", pendingReports.size() + completedReports.size());
         for (auto report : pendingReports) {

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -35,7 +35,11 @@ static const char* kGargamelleURL = "https://ggml.scintillatorsynth.org/api/dump
 
 void logReport(const crashpad::CrashReportDatabase::Report& report) {
     struct tm createTime;
+#if _MSC_VER
+    localtime_s(&createTime, &report.creation_time);
+#else
     localtime_r(&report.creation_time, &createTime);
+#endif
     std::array<char, 128> timeBuf;
     strftime(timeBuf.data(), sizeof(timeBuf), "%a %d %b %H:%M:%S %Y", &createTime);
     spdlog::info("    id: {}, on: {}, uploaded: {}", report.uuid.ToString(), timeBuf.data(),

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -3,8 +3,8 @@
 #include "infra/Version.hpp"
 
 #if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4100)
+#    pragma warning(push)
+#    pragma warning(disable : 4100)
 #elif __GNUC__ || __clang__
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -13,7 +13,7 @@
 #include <client/crashpad_client.h>
 #include <client/settings.h>
 #if _MSC_VER
-#pragma warning(pop)
+#    pragma warning(pop)
 #elif __GNUC__ || __clang__
 #    pragma GCC diagnostic pop
 #endif
@@ -35,7 +35,7 @@ static const char* kGargamelleURL = "https://ggml.scintillatorsynth.org/api/dump
 
 void logReport(const crashpad::CrashReportDatabase::Report& report) {
     struct tm createTime;
-    localtime_s(&createTime, &report.creation_time);
+    localtime_r(&report.creation_time, &createTime);
     std::array<char, 128> timeBuf;
     strftime(timeBuf.data(), sizeof(timeBuf), "%a %d %b %H:%M:%S %Y", &createTime);
     spdlog::info("    id: {}, on: {}, uploaded: {}", report.uuid.ToString(), timeBuf.data(),

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -2,9 +2,17 @@
 
 #include "infra/Version.hpp"
 
+#if __GNUC__ || __clang__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <client/crash_report_database.h>
 #include <client/crashpad_client.h>
 #include <client/settings.h>
+#if __GNUC__ || __clang__
+#    pragma GCC diagnostic pop
+#endif
+
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
 #include <util/misc/capture_context.h>

--- a/src/infra/CrashReporter.cpp
+++ b/src/infra/CrashReporter.cpp
@@ -2,14 +2,19 @@
 
 #include "infra/Version.hpp"
 
-#if __GNUC__ || __clang__
+#if _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100)
+#elif __GNUC__ || __clang__
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 #include <client/crash_report_database.h>
 #include <client/crashpad_client.h>
 #include <client/settings.h>
-#if __GNUC__ || __clang__
+#if _MSC_VER
+#pragma warning(pop)
+#elif __GNUC__ || __clang__
 #    pragma GCC diagnostic pop
 #endif
 

--- a/src/osc/Address.hpp
+++ b/src/osc/Address.hpp
@@ -1,7 +1,7 @@
 #ifndef SRC_OSC_ADDRESS_HPP_
 #define SRC_OSC_ADDRESS_HPP_
 
-#include "lo/lo.h"
+#include "osc/LOIncludes.hpp"
 
 namespace scin { namespace osc {
 

--- a/src/osc/BlobMessage.hpp
+++ b/src/osc/BlobMessage.hpp
@@ -1,12 +1,13 @@
 #ifndef SRC_OSC_BLOB_MESSAGE_HPP_
 #define SRC_OSC_BLOB_MESSAGE_HPP_
 
-#include "lo/lo.h"
+#include "osc/LOIncludes.hpp"
 
 #include <memory>
 
 namespace scin { namespace osc {
-/*! Can extract a copy of a message from a OSC blob lo_blob data structure.
+
+/*! Can extract a copy of a message from an OSC blob lo_blob data structure, allowing it to be sent as a lo_message.
  */
 class BlobMessage {
 public:

--- a/src/osc/Dispatcher.hpp
+++ b/src/osc/Dispatcher.hpp
@@ -3,7 +3,7 @@
 
 #include "osc/commands/Command.hpp"
 
-#include "lo/lo.h"
+#include "osc/LOIncludes.hpp"
 
 #include <array>
 #include <functional>

--- a/src/osc/LOIncludes.hpp
+++ b/src/osc/LOIncludes.hpp
@@ -1,0 +1,13 @@
+#ifndef SRC_OSC_LO_INCLUDES_HPP_
+#define SRC_OSC_LO_INCLUDES_HPP_
+
+#if __GNUC__ || __clang__
+#pragma GCC system_header
+#endif
+
+extern "C" {
+#include <lo/lo.h>
+}
+
+#endif // SRC_OSC_LO_INCLUDES_HPP_
+

--- a/src/osc/LOIncludes.hpp
+++ b/src/osc/LOIncludes.hpp
@@ -1,13 +1,17 @@
 #ifndef SRC_OSC_LO_INCLUDES_HPP_
 #define SRC_OSC_LO_INCLUDES_HPP_
 
-#if __GNUC__ || __clang__
+#if _MSC_VER
+#pragma warning(push, 1)
+#elif __GNUC__ || __clang__
 #pragma GCC system_header
 #endif
 
-extern "C" {
 #include <lo/lo.h>
-}
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // SRC_OSC_LO_INCLUDES_HPP_
 

--- a/src/osc/LOIncludes.hpp
+++ b/src/osc/LOIncludes.hpp
@@ -1,17 +1,13 @@
 #ifndef SRC_OSC_LO_INCLUDES_HPP_
 #define SRC_OSC_LO_INCLUDES_HPP_
 
-#if _MSC_VER
-#pragma warning(push, 1)
-#elif __GNUC__ || __clang__
+#if __GNUC__ || __clang__
 #pragma GCC system_header
 #endif
 
+extern "C" {
 #include <lo/lo.h>
-
-#if _MSC_VER
-#pragma warning(pop)
-#endif
+}
 
 #endif // SRC_OSC_LO_INCLUDES_HPP_
 

--- a/src/osc/LOIncludes.hpp
+++ b/src/osc/LOIncludes.hpp
@@ -2,7 +2,7 @@
 #define SRC_OSC_LO_INCLUDES_HPP_
 
 #if __GNUC__ || __clang__
-#pragma GCC system_header
+#    pragma GCC system_header
 #endif
 
 extern "C" {
@@ -10,4 +10,3 @@ extern "C" {
 }
 
 #endif // SRC_OSC_LO_INCLUDES_HPP_
-

--- a/src/osc/commands/AdvanceFrame.cpp
+++ b/src/osc/commands/AdvanceFrame.cpp
@@ -18,7 +18,7 @@ void AdvanceFrame::processMessage(int argc, lo_arg** argv, const char* types, lo
         m_dispatcher->respond(address, "/scin_done", "/scin_nrt_advanceFrame");
         return;
     }
-    if (std::strncmp(types, "ii", 2) != 0) {
+    if (argc < 2 || std::strncmp(types, "ii", 2) != 0) {
         spdlog::error("AdvanceFrame got wrong argument types {}", types);
         m_dispatcher->respond(address, "/scin_done", "/scin_nrt_advanceFrame");
         return;
@@ -28,7 +28,7 @@ void AdvanceFrame::processMessage(int argc, lo_arg** argv, const char* types, lo
     int32_t denominator = *reinterpret_cast<int32_t*>(argv[1]);
     double dt = static_cast<double>(numerator) / static_cast<double>(denominator);
     std::shared_ptr<Address> origin(new Address(address));
-    m_dispatcher->offscreen()->advanceFrame(dt, [this, origin](size_t frameNumber) {
+    m_dispatcher->offscreen()->advanceFrame(dt, [this, origin](size_t /* frameNumber */) {
         spdlog::info("got callback from advanceFrame");
         m_dispatcher->respond(origin->get(), "/scin_done", "/scin_nrt_advanceFrame");
     });

--- a/src/osc/commands/Command.cpp.in
+++ b/src/osc/commands/Command.cpp.in
@@ -4,6 +4,15 @@
 
 #include <cstring>
 
+#if _MSC_VER
+// Disable MSVC warning on generated code.
+#pragma warning(push)
+#pragma warning(disable: 4267)
+#elif __GNUC__ || __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 namespace {
 
 %}
@@ -40,6 +49,12 @@ uploadCrashReport,  scin::osc::commands::Command::Number::kUploadCrashReport
 %%
 
 } // namespace
+
+#if _MSC_VER
+#pragma warning(pop)
+#elif __GNUC__ || __clang__
+#pragma GCC diagnostic pop
+#endif
 
 namespace scin { namespace osc { namespace commands {
 

--- a/src/osc/commands/Command.cpp.in
+++ b/src/osc/commands/Command.cpp.in
@@ -4,10 +4,6 @@
 
 #include <cstring>
 
-// Some of the gperf generated code uses the register keyword, which is deprecated in C++17.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wregister"
-
 namespace {
 
 %}
@@ -44,8 +40,6 @@ uploadCrashReport,  scin::osc::commands::Command::Number::kUploadCrashReport
 %%
 
 } // namespace
-
-#pragma clang diagnostic pop
 
 namespace scin { namespace osc { namespace commands {
 

--- a/src/osc/commands/Command.hpp
+++ b/src/osc/commands/Command.hpp
@@ -13,7 +13,7 @@ namespace commands {
 
 class Command {
 public:
-    enum Number : int {
+    enum Number : size_t {
         // Master Controls
         kNone = 0,
         kNotify = 1,

--- a/src/osc/commands/Command.hpp
+++ b/src/osc/commands/Command.hpp
@@ -1,7 +1,7 @@
 #ifndef SRC_OSC_COMMANDS_COMMAND_HPP_
 #define SRC_OSC_COMMANDS_COMMAND_HPP_
 
-#include "lo/lo.h"
+#include "osc/LOIncludes.hpp"
 
 #include <string>
 

--- a/src/osc/commands/DefFree.cpp
+++ b/src/osc/commands/DefFree.cpp
@@ -15,7 +15,7 @@ DefFree::DefFree(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 DefFree::~DefFree() {}
 
-void DefFree::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void DefFree::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
     std::vector<std::string> names;
     for (int i = 0; i < argc; ++i) {
         if (types[i] == LO_STRING) {

--- a/src/osc/commands/DefLoad.cpp
+++ b/src/osc/commands/DefLoad.cpp
@@ -31,7 +31,7 @@ void DefLoad::processMessage(int argc, lo_arg** argv, const char* types, lo_addr
         }
     }
     std::shared_ptr<Address> origin(new Address(address));
-    m_dispatcher->async()->scinthDefLoadFile(path, [this, origin, onCompletion](int) {
+    m_dispatcher->async()->scinthDefLoadFile(path, [this, origin, onCompletion](size_t) {
         if (onCompletion) {
             m_dispatcher->processMessageFrom(origin->get(), onCompletion);
         }

--- a/src/osc/commands/DefLoadDir.cpp
+++ b/src/osc/commands/DefLoadDir.cpp
@@ -32,7 +32,7 @@ void DefLoadDir::processMessage(int argc, lo_arg** argv, const char* types, lo_a
         }
     }
     std::shared_ptr<Address> origin(new Address(address));
-    m_dispatcher->async()->scinthDefLoadDirectory(path, [this, origin, onCompletion](int) {
+    m_dispatcher->async()->scinthDefLoadDirectory(path, [this, origin, onCompletion](size_t) {
         if (onCompletion) {
             m_dispatcher->processMessageFrom(origin->get(), onCompletion);
         }

--- a/src/osc/commands/DumpOSC.cpp
+++ b/src/osc/commands/DumpOSC.cpp
@@ -12,8 +12,8 @@ DumpOSC::DumpOSC(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 DumpOSC::~DumpOSC() {}
 
-void DumpOSC::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
-    if (std::strncmp(types, "i", 1) != 0) {
+void DumpOSC::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
+    if (argc < 1 || std::strncmp(types, "i", 1) != 0) {
         spdlog::error("DumpOSC got wrong argument types {}", types);
         return;
     }

--- a/src/osc/commands/GroupFreeAll.cpp
+++ b/src/osc/commands/GroupFreeAll.cpp
@@ -13,7 +13,8 @@ GroupFreeAll::GroupFreeAll(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 GroupFreeAll::~GroupFreeAll() {}
 
-void GroupFreeAll::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void GroupFreeAll::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* types */,
+                                  lo_address /* address */) {
     m_dispatcher->compositor()->groupFreeAll();
 }
 

--- a/src/osc/commands/ImageBufferQuery.cpp
+++ b/src/osc/commands/ImageBufferQuery.cpp
@@ -19,16 +19,21 @@ void ImageBufferQuery::processMessage(int argc, lo_arg** argv, const char* types
             return;
         }
         int imageID = *reinterpret_cast<int32_t*>(argv[i]);
-        int size = 0;
-        int width = -1;
-        int height = -1;
-        if (!m_dispatcher->compositor()->queryImage(imageID, size, width, height)) {
+        size_t size = 0;
+        uint32_t width = 0;
+        uint32_t height = 0;
+        if (m_dispatcher->compositor()->queryImage(imageID, size, width, height)) {
+            lo_message_add_int32(message, imageID);
+            lo_message_add_int32(message, static_cast<int32_t>(size));
+            lo_message_add_int32(message, width);
+            lo_message_add_int32(message, height);
+        } else {
             spdlog::warn("OSC imageBufferQuery got query for unknown imageID {}.", imageID);
+            lo_message_add_int32(message, imageID);
+            lo_message_add_int32(message, -1);
+            lo_message_add_int32(message, -1);
+            lo_message_add_int32(message, -1);
         }
-        lo_message_add_int32(message, imageID);
-        lo_message_add_int32(message, size);
-        lo_message_add_int32(message, width);
-        lo_message_add_int32(message, height);
     }
 
     // The dispatcher will free the message.

--- a/src/osc/commands/LogAppend.cpp
+++ b/src/osc/commands/LogAppend.cpp
@@ -12,8 +12,8 @@ LogAppend::LogAppend(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 LogAppend::~LogAppend() {}
 
-void LogAppend::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
-    if (std::strncmp(types, "is", 2) != 0) {
+void LogAppend::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
+    if (argc < 2 || std::strncmp(types, "is", 2) != 0) {
         spdlog::error("OSC LogAppend got invalid or absent arguments in message.");
         return;
     }

--- a/src/osc/commands/LogCrashReports.cpp
+++ b/src/osc/commands/LogCrashReports.cpp
@@ -13,7 +13,7 @@ LogCrashReports::LogCrashReports(osc::Dispatcher* dispatcher): Command(dispatche
 
 LogCrashReports::~LogCrashReports() {}
 
-void LogCrashReports::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void LogCrashReports::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* types */, lo_address address) {
     if (m_dispatcher->crashReporter()) {
         m_dispatcher->crashReporter()->logCrashReports();
         m_dispatcher->crashReporter()->closeDatabase();

--- a/src/osc/commands/LogLevel.cpp
+++ b/src/osc/commands/LogLevel.cpp
@@ -11,7 +11,7 @@ LogLevel::LogLevel(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 LogLevel::~LogLevel() {}
 
-void LogLevel::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void LogLevel::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
     if (argc < 1 || types[0] != LO_INT32) {
         spdlog::error("OSC LogLevel got invalid or absent level argument in message.");
         return;

--- a/src/osc/commands/NodeFree.cpp
+++ b/src/osc/commands/NodeFree.cpp
@@ -13,7 +13,7 @@ NodeFree::NodeFree(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 NodeFree::~NodeFree() {}
 
-void NodeFree::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void NodeFree::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
     std::vector<int> nodes;
     for (int i = 0; i < argc; ++i) {
         if (types[i] == LO_INT32) {

--- a/src/osc/commands/NodeRun.cpp
+++ b/src/osc/commands/NodeRun.cpp
@@ -13,7 +13,7 @@ NodeRun::NodeRun(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 NodeRun::~NodeRun() {}
 
-void NodeRun::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void NodeRun::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
     std::vector<std::pair<int, int>> pairs;
     if (argc % 2) {
         spdlog::warn("OSC NodeRun got odd number of arguments, ignoring last value.");

--- a/src/osc/commands/NodeSet.cpp
+++ b/src/osc/commands/NodeSet.cpp
@@ -14,7 +14,7 @@ NodeSet::NodeSet(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 NodeSet::~NodeSet() {}
 
-void NodeSet::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void NodeSet::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
     if (argc < 1 || types[0] != LO_INT32) {
         spdlog::error("OSC NodeSet expecting integer ScinthID as first argument.");
         return;

--- a/src/osc/commands/Notify.cpp
+++ b/src/osc/commands/Notify.cpp
@@ -8,7 +8,7 @@ Notify::Notify(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 Notify::~Notify() {}
 
-void Notify::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void Notify::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* types */, lo_address /* address */) {
     // TBD rest of notification system.
 }
 

--- a/src/osc/commands/Quit.cpp
+++ b/src/osc/commands/Quit.cpp
@@ -9,7 +9,7 @@ Quit::Quit(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 Quit::~Quit() {}
 
-void Quit::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void Quit::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* types */, lo_address address) {
     std::shared_ptr<Address> origin(new Address(address));
     m_dispatcher->callQuitHandler(origin);
 }

--- a/src/osc/commands/ScinVersion.cpp
+++ b/src/osc/commands/ScinVersion.cpp
@@ -9,7 +9,7 @@ ScinVersion::ScinVersion(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 ScinVersion::~ScinVersion() {}
 
-void ScinVersion::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void ScinVersion::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* types */, lo_address address) {
     m_dispatcher->respond(address, "/scin_version.reply", "scinsynth", kScinVersionMajor, kScinVersionMinor,
                           kScinVersionPatch, kScinBranch, kScinCommitHash);
 }

--- a/src/osc/commands/ScinthNew.cpp
+++ b/src/osc/commands/ScinthNew.cpp
@@ -15,7 +15,7 @@ ScinthNew::ScinthNew(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 ScinthNew::~ScinthNew() {}
 
-void ScinthNew::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void ScinthNew::processMessage(int argc, lo_arg** argv, const char* types, lo_address /* address */) {
     if (std::strncmp(types, "si", 2) != 0) {
         spdlog::error("OSC ScinthNew got incomplete or incorrect types");
         return;

--- a/src/osc/commands/ScreenShot.hpp
+++ b/src/osc/commands/ScreenShot.hpp
@@ -25,7 +25,7 @@ public:
 private:
     std::mutex m_mutex;
     size_t m_encodersSerial;
-    std::unordered_map<int, std::shared_ptr<av::ImageEncoder>> m_encoders;
+    std::unordered_map<size_t, std::shared_ptr<av::ImageEncoder>> m_encoders;
 };
 
 } // namespace commands

--- a/src/osc/commands/Status.cpp
+++ b/src/osc/commands/Status.cpp
@@ -23,7 +23,8 @@ void Status::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* 
     m_dispatcher->logger()->getCounts(numberOfWarnings, numberOfErrors);
     m_dispatcher->compositor()->getGraphicsMemoryBudget(graphicsBytesUsed, graphicsBytesAvailable);
     m_dispatcher->frameTimer()->getStats(targetFrameRate, meanFrameRate, lateFrames);
-    m_dispatcher->respond(address, "/scin_status.reply", m_dispatcher->compositor()->numberOfRunningScinths(), 1,
+    m_dispatcher->respond(address, "/scin_status.reply",
+                          static_cast<int32_t>(m_dispatcher->compositor()->numberOfRunningScinths()), 1,
                           static_cast<int32_t>(m_dispatcher->archetypes()->numberOfAbstractScinthDefs()),
                           static_cast<int32_t>(numberOfWarnings), static_cast<int32_t>(numberOfErrors),
                           static_cast<double>(graphicsBytesUsed), static_cast<double>(graphicsBytesAvailable),

--- a/src/osc/commands/Status.cpp
+++ b/src/osc/commands/Status.cpp
@@ -12,7 +12,7 @@ Status::Status(osc::Dispatcher* dispatcher): Command(dispatcher) {}
 
 Status::~Status() {}
 
-void Status::processMessage(int argc, lo_arg** argv, const char* types, lo_address address) {
+void Status::processMessage(int /* argc */, lo_arg** /* argv */, const char* /* types */, lo_address address) {
     size_t numberOfWarnings = 0;
     size_t numberOfErrors = 0;
     size_t graphicsBytesUsed = 0;

--- a/src/run_unittests.cpp
+++ b/src/run_unittests.cpp
@@ -1,5 +1,6 @@
+#include "base/GTestIncludes.hpp"
+
 #include "gflags/gflags.h"
-#include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
 
 DEFINE_int32(logLevel, 6, "Verbosity of logs, 0 most verbose, 6 is off.");

--- a/src/scinsynth.cpp
+++ b/src/scinsynth.cpp
@@ -247,7 +247,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (!device && chooser.bestDeviceIndex() >= 0) {
+    if (!device && chooser.bestDeviceIndex() < chooser.devices().size()) {
         auto info = chooser.devices().at(chooser.bestDeviceIndex());
         if (FLAGS_createWindow && !info.supportsWindow()) {
             spdlog::error("Automatically chosen device {} doesn't support window rendering.", info.name());

--- a/src/scinsynth.cpp
+++ b/src/scinsynth.cpp
@@ -1,23 +1,18 @@
 #include "audio/PortAudio.hpp"
-#include "av/AVIncludes.hpp"
 #include "base/Archetypes.hpp"
 #include "base/FileSystem.hpp"
-#include "comp/Async.hpp" // TODO: audit includes
+#include "comp/Async.hpp"
 #include "comp/Compositor.hpp"
 #include "comp/FrameTimer.hpp"
 #include "comp/Offscreen.hpp"
-#include "comp/Pipeline.hpp"
 #include "comp/Window.hpp"
 #include "infra/CrashReporter.hpp"
 #include "infra/Logger.hpp"
 #include "infra/Version.hpp"
 #include "osc/Dispatcher.hpp"
-#include "vulkan/Buffer.hpp"
-#include "vulkan/CommandPool.hpp"
 #include "vulkan/Device.hpp"
 #include "vulkan/DeviceChooser.hpp"
 #include "vulkan/Instance.hpp"
-#include "vulkan/Shader.hpp"
 #include "vulkan/Vulkan.hpp"
 
 #include <fmt/core.h>
@@ -301,9 +296,9 @@ int main(int argc, char* argv[]) {
     async->run(FLAGS_asyncWorkerThreads);
 
     // Chain async calls to load VGens, then ScinthDefs.
-    async->vgenLoadDirectory(quarkPath / "vgens", [async, &quarkPath, compositor](int) {
+    async->vgenLoadDirectory(quarkPath / "vgens", [async, &quarkPath, compositor](size_t) {
         async->scinthDefLoadDirectory(quarkPath / "scinthdefs",
-                                      [](int) { spdlog::info("finished loading predefined VGens and ScinthDefs."); });
+                                      [](size_t) { spdlog::info("finished loading predefined VGens and ScinthDefs."); });
     });
 
     std::function<void()> quitHandler;

--- a/src/scinsynth.cpp
+++ b/src/scinsynth.cpp
@@ -297,8 +297,9 @@ int main(int argc, char* argv[]) {
 
     // Chain async calls to load VGens, then ScinthDefs.
     async->vgenLoadDirectory(quarkPath / "vgens", [async, &quarkPath, compositor](size_t) {
-        async->scinthDefLoadDirectory(quarkPath / "scinthdefs",
-                                      [](size_t) { spdlog::info("finished loading predefined VGens and ScinthDefs."); });
+        async->scinthDefLoadDirectory(quarkPath / "scinthdefs", [](size_t) {
+            spdlog::info("finished loading predefined VGens and ScinthDefs.");
+        });
     });
 
     std::function<void()> quitHandler;

--- a/src/vulkan/CommandBuffer.cpp
+++ b/src/vulkan/CommandBuffer.cpp
@@ -24,7 +24,7 @@ bool CommandBuffer::create(size_t count, bool isPrimary) {
     } else {
         allocInfo.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     }
-    allocInfo.commandBufferCount = count;
+    allocInfo.commandBufferCount = static_cast<uint32_t>(count);
 
     if (vkAllocateCommandBuffers(m_device->get(), &allocInfo, m_commandBuffers.data()) != VK_SUCCESS) {
         spdlog::error("error allocating command buffers.");
@@ -40,7 +40,8 @@ void CommandBuffer::destroy() {
     m_secondaryCommands.clear();
 
     if (m_commandBuffers.size()) {
-        vkFreeCommandBuffers(m_device->get(), m_commandPool->get(), m_commandBuffers.size(), m_commandBuffers.data());
+        vkFreeCommandBuffers(m_device->get(), m_commandPool->get(), static_cast<uint32_t>(m_commandBuffers.size()),
+            m_commandBuffers.data());
         m_commandBuffers.clear();
     }
 }

--- a/src/vulkan/CommandBuffer.cpp
+++ b/src/vulkan/CommandBuffer.cpp
@@ -41,7 +41,7 @@ void CommandBuffer::destroy() {
 
     if (m_commandBuffers.size()) {
         vkFreeCommandBuffers(m_device->get(), m_commandPool->get(), static_cast<uint32_t>(m_commandBuffers.size()),
-            m_commandBuffers.data());
+                             m_commandBuffers.data());
         m_commandBuffers.clear();
     }
 }

--- a/src/vulkan/DeviceChooser.cpp
+++ b/src/vulkan/DeviceChooser.cpp
@@ -6,7 +6,7 @@
 
 namespace scin { namespace vk {
 
-DeviceChooser::DeviceChooser(std::shared_ptr<Instance> instance): m_instance(instance), m_bestDeviceIndex(-1) {}
+DeviceChooser::DeviceChooser(std::shared_ptr<Instance> instance): m_instance(instance), m_bestDeviceIndex(0ull) {}
 
 DeviceChooser::~DeviceChooser() {}
 

--- a/src/vulkan/DeviceChooser.hpp
+++ b/src/vulkan/DeviceChooser.hpp
@@ -26,14 +26,14 @@ public:
 
     const std::vector<DeviceInfo>& devices() const { return m_devices; }
 
-    /*! Returns the index of the most performant device, or -1 if no devices were found.
+    /*! Returns the index of the highest performance device, or zero if there are no devices detected.
      */
-    int bestDeviceIndex() const { return m_bestDeviceIndex; }
+    size_t bestDeviceIndex() const { return m_bestDeviceIndex; }
 
 private:
     std::shared_ptr<Instance> m_instance;
     std::vector<DeviceInfo> m_devices;
-    int m_bestDeviceIndex;
+    size_t m_bestDeviceIndex;
 };
 
 } // namespace vk

--- a/src/vulkan/Framebuffer.cpp
+++ b/src/vulkan/Framebuffer.cpp
@@ -13,7 +13,7 @@ Framebuffer::Framebuffer(std::shared_ptr<Device> device): m_device(device), m_ca
 Framebuffer::~Framebuffer() { destroy(); }
 
 bool Framebuffer::create(int width, int height, size_t numberOfImages) {
-    for (auto i = 0; i < numberOfImages; ++i) {
+    for (size_t i = 0; i < numberOfImages; ++i) {
         std::shared_ptr<FramebufferImage> image(new FramebufferImage(m_device));
         if (!image->create(width, height)) {
             spdlog::error("framebuffer failed to create images.");

--- a/src/vulkan/Image.hpp
+++ b/src/vulkan/Image.hpp
@@ -66,7 +66,7 @@ public:
     virtual bool create(uint32_t width, uint32_t height) = 0;
     void destroy();
 
-    int size() const { return m_info.size; }
+    size_t size() const { return m_info.size; }
 
 protected:
     VmaAllocation m_allocation;

--- a/src/vulkan/Instance.cpp
+++ b/src/vulkan/Instance.cpp
@@ -33,31 +33,6 @@ void destroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT
 
 const std::vector<const char*> validationLayers = { "VK_LAYER_KHRONOS_validation" };
 
-bool checkValidationLayerSupport() {
-    uint32_t layerCount;
-    vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
-
-    std::vector<VkLayerProperties> availableLayers(layerCount);
-    vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
-
-    for (auto layerName : validationLayers) {
-        bool layerFound = false;
-
-        for (const auto& layerProperties : availableLayers) {
-            if (strcmp(layerName, layerProperties.layerName) == 0) {
-                layerFound = true;
-                break;
-            }
-        }
-
-        if (!layerFound) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
                                                     VkDebugUtilsMessageTypeFlagsEXT type,
                                                     const VkDebugUtilsMessengerCallbackDataEXT* callbackData,

--- a/src/vulkan/Instance.cpp
+++ b/src/vulkan/Instance.cpp
@@ -34,9 +34,9 @@ void destroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT
 const std::vector<const char*> validationLayers = { "VK_LAYER_KHRONOS_validation" };
 
 static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
-                                                    VkDebugUtilsMessageTypeFlagsEXT type,
+                                                    VkDebugUtilsMessageTypeFlagsEXT /* type */,
                                                     const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
-                                                    void* userData) {
+                                                    void* /* userData */) {
     // The Severity bits can be combined, so we key log severity off of the most severe bit.
     if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
         spdlog::error("Vulkan: {}", callbackData->pMessage);

--- a/src/vulkan/Shader.cpp
+++ b/src/vulkan/Shader.cpp
@@ -6,8 +6,7 @@
 
 namespace scin { namespace vk {
 
-Shader::Shader(Kind kind, std::shared_ptr<Device> device, const std::string& entryPoint):
-    m_kind(kind),
+Shader::Shader(std::shared_ptr<Device> device, const std::string& entryPoint):
     m_device(device),
     m_entryPoint(entryPoint),
     m_shaderModule(VK_NULL_HANDLE) {}

--- a/src/vulkan/Shader.hpp
+++ b/src/vulkan/Shader.hpp
@@ -13,7 +13,7 @@ class Device;
 class Shader {
 public:
     enum Kind { kCompute, kVertex, kFragment };
-    Shader(Kind kind, std::shared_ptr<Device> device, const std::string& entryPoint);
+    Shader(std::shared_ptr<Device> device, const std::string& entryPoint);
     ~Shader();
 
     bool create(const char* spvBytes, size_t byteSize);
@@ -23,7 +23,6 @@ public:
     const char* entryPoint() const { return m_entryPoint.data(); }
 
 private:
-    Kind m_kind;
     std::shared_ptr<Device> m_device;
     std::string m_entryPoint;
     std::unique_ptr<uint32_t[]> m_spvBytes;

--- a/src/vulkan/Vulkan.hpp
+++ b/src/vulkan/Vulkan.hpp
@@ -2,8 +2,8 @@
 #define SRC_SCIN_INCLUDE_VULKAN_HPP_
 
 #if _MSC_VER
-#define VK_USE_PLATFORM_WIN32_KHR
-#define WIN32_LEAN_AND_MEAN
+#    define VK_USE_PLATFORM_WIN32_KHR
+#    define WIN32_LEAN_AND_MEAN
 #endif
 
 #define GLFW_INCLUDE_NONE // Keep GLFW from including GL headers

--- a/src/vulkan/Vulkan.hpp
+++ b/src/vulkan/Vulkan.hpp
@@ -1,6 +1,10 @@
 #ifndef SRC_SCIN_INCLUDE_VULKAN_HPP_
 #define SRC_SCIN_INCLUDE_VULKAN_HPP_
 
+#if _MSC_VER
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
+
 #define GLFW_INCLUDE_NONE // Keep GLFW from including GL headers
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>

--- a/src/vulkan/Vulkan.hpp
+++ b/src/vulkan/Vulkan.hpp
@@ -3,6 +3,7 @@
 
 #if _MSC_VER
 #define VK_USE_PLATFORM_WIN32_KHR
+#define WIN32_LEAN_AND_MEAN
 #endif
 
 #define GLFW_INCLUDE_NONE // Keep GLFW from including GL headers


### PR DESCRIPTION
## Purpose and motivation

Fixes #59. Catching and fixing compiler warnings can uncover a lot of potential bugs and API inconsistencies in software. They tend to accumulate over time unless they are treated as errors. So we wipe the slate clean and then enforce keeping it clean.

## Implementation

Turn all all warnings and errors, then fix everything that breaks.

## Types of changes

* Bug fix
* Enhancement

## Status

- [x] This PR is ready for review
