### PR TITLE
include libstdc++ and libgcc_s in AppImage

### DIFF
--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -78,6 +78,5 @@ else
 
     # signal the installer to include libstdc++ as optional, to support older Linuxes
     cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $TRAVIS_BUILD_DIR/build/install-ext/lib
-    cp /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 $TRAVIS_BUILD_DIR/build/install-ext/lib
 fi
 

--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -75,5 +75,9 @@ else
     ./configure --prefix=/usr/local
     make
     sudo make install
+
+    # signal the installer to include libstdc++ as optional, to support older Linuxes
+    cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $TRAVIS_BUILD_DIR/build/install-ext/lib
+    cp /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 $TRAVIS_BUILD_DIR/build/install-ext/lib
 fi
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -604,9 +604,6 @@ elseif(UNIX)
         install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/exec.so"
             DESTINATION "${SCIN_APPDIR}/usr/optional"
         )
-        install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/libgcc_s.so.1"
-            DESTINATION "${SCIN_APPDIR}/usr/optional"
-        )
     endif()
     # Copy the swiftshader binary and metadata
     install(DIRECTORY "${SCIN_EXT_INSTALL_DIR}/share/vulkan/icd.d"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,10 +319,21 @@ elseif(UNIX)
         BUILD_COMMAND ""
         INSTALL_COMMAND chmod u+x <DOWNLOADED_FILE> && cp <DOWNLOADED_FILE> ${SCIN_EXT_INSTALL_DIR}/bin
     )
+    ExternalProject_add(checkrt
+        PREFIX ext
+        STEP_TARGETS install
+        URL https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so
+        DOWNLOAD_NO_EXTRACT ON
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND cp <DOWNLOADED_FILE> ${SCIN_EXT_INSTALL_DIR}/lib/exec.so
+    )
     set(SCIN_LINUX_DEPLOY "${SCIN_EXT_INSTALL_DIR}/bin/linuxdeploy-x86_64.AppImage")
     # We need the linuxdeploy tool to construct the AppImage.
     add_dependencies(scinsynth
         linuxdeploy-install
+        checkrt-install
     )
 elseif(WIN32)
     add_executable(scinsynth ${scintillator_synth_files})
@@ -570,6 +581,7 @@ elseif(UNIX)
         )
         file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/share/vulkan/explicit_layer.d)
         file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/share/vulkan/icd.d)
+        file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/optional)
     "
     VERBATIM
     )
@@ -581,6 +593,21 @@ elseif(UNIX)
     install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/libVkLayer_khronos_validation.so"
         DESTINATION "${SCIN_APPDIR}/usr/share/vulkan/explicit_layer.d"
     )
+    # Optionally copy the libstdc++ libraries (and supporting code) if they exist. This is used to signal the inclusion
+    # of these libraries for compatibility on older version of Linux, and is usually only done on official builds for
+    # distribution.
+    if (EXISTS "${SCIN_EXT_INSTALL_DIR}/lib/libstdc++.so.6")
+        message(STATUS "including libstdc++.so.6 in the AppImage install")
+        install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/libstdc++.so.6"
+            DESTINATION "${SCIN_APPDIR}/usr/optional"
+        )
+        install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/exec.so"
+            DESTINATION "${SCIN_APPDIR}/usr/optional"
+        )
+        install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/libgcc_s.so.1"
+            DESTINATION "${SCIN_APPDIR}/usr/optional"
+        )
+    endif()
     # Copy the swiftshader binary and metadata
     install(DIRECTORY "${SCIN_EXT_INSTALL_DIR}/share/vulkan/icd.d"
         DESTINATION "${SCIN_APPDIR}/usr/share/vulkan"
@@ -593,6 +620,7 @@ elseif(UNIX)
     # tool knows where to look for the dependent libraries.
     install(CODE "
         set(ENV{LD_LIBRARY_PATH} \"${SCIN_EXT_INSTALL_DIR}/lib\")
+        set(ENV{VERSION} ${GIT_COMMIT_HASH})
         execute_process(
             COMMAND ${SCIN_LINUX_DEPLOY} -d ${CMAKE_CURRENT_BINARY_DIR}/scinsynth.desktop -i ${PROJECT_SOURCE_DIR}/src/linux/scinsynth.png -e ${CMAKE_CURRENT_BINARY_DIR}/scinsynth --custom-apprun=${PROJECT_SOURCE_DIR}/src/linux/AppRun --appdir ${SCIN_APPDIR} --output appimage
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -684,8 +684,8 @@ if (UNIX AND NOT APPLE AND CMAKE_BUILD_TYPE STREQUAL "Coverage")
         set(LLVM_COV llvm-cov)
     endif()
 
-    set(SCIN_TEST_IMAGES_ENV "LLVM_PROFILE_FILE=scin_test_images.profraw")
-    set(SCIN_TEST_OSC_ENV "LLVM_PROFILE_FILE=scin_test_osc.profraw")
+    set(SCIN_TEST_IMAGES_ENV "LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/scin_test_images.profraw")
+    set(SCIN_TEST_OSC_ENV "LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/scin_test_osc.profraw")
 
     add_custom_command(OUTPUT scinsynth_coverage.profdata
         COMMAND ${CMAKE_COMMAND} -E env "LLVM_PROFILE_FILE=run_unittests.profraw" ./run_unittests

--- a/src/linux/AppRun
+++ b/src/linux/AppRun
@@ -75,6 +75,6 @@ else
     CRASHPAD_HANDLER="--crashpadHandlerPath=$HERE/usr/bin/crashpad_handler"
 fi
 
-$exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
-exit $?
+exec $exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
+# exit $?
 

--- a/src/linux/AppRun
+++ b/src/linux/AppRun
@@ -75,6 +75,6 @@ else
     CRASHPAD_HANDLER="--crashpadHandlerPath=$HERE/usr/bin/crashpad_handler"
 fi
 
-exec $exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
-# exit $?
+$exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
+exit $?
 

--- a/src/linux/AppRun
+++ b/src/linux/AppRun
@@ -5,6 +5,51 @@
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 
+cd $HERE
+
+### This section copied verbatim from https://github.com/darealshinji/AppImageKit-checkrt/blob/master/AppRun.sh, used
+# to inject a newer libstdc++ for binaries only inside this AppImage, and only on systems where the version in
+# /usr/optional is newer than whats installed on the system.
+cxxpre=""
+gccpre=""
+execpre=""
+libc6arch="libc6,x86-64"
+exec="./bin/$(sed -n 's|^Exec=||p' $(ls -1 *.desktop))"
+
+if [ -n "$APPIMAGE" ] && [ "$(file -b "$APPIMAGE" | cut -d, -f2)" != " x86-64" ]; then
+  libc6arch="libc6"
+fi
+
+cd "usr"
+
+if [ -e "./optional/libstdc++/libstdc++.so.6" ]; then
+  lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libstdc++\.so\.6 ($libc6arch)" | awk 'NR==1{print $NF}')"
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GLIBCXX_3\.4' | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/libstdc++/libstdc++.so.6" | grep -e '^GLIBCXX_3\.4' | tail -n1)
+  if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
+    cxxpath="./optional/libstdc++:"
+  fi
+fi
+
+if [ -e "./optional/libgcc/libgcc_s.so.1" ]; then
+  lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libgcc_s\.so\.1 ($libc6arch)" | awk 'NR==1{print $NF}')"
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/libgcc/libgcc_s.so.1" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
+    gccpath="./optional/libgcc:"
+  fi
+fi
+
+if [ -n "$cxxpath" ] || [ -n "$gccpath" ]; then
+  if [ -e "./optional/exec.so" ]; then
+    execpre=""
+    export LD_PRELOAD="./optional/exec.so:${LD_PRELOAD}"
+  fi
+  export LD_LIBRARY_PATH="${cxxpath}${gccpath}${LD_LIBRARY_PATH}"
+fi
+
+### End copied section.
+
 # The Vulkan Loader will search a predefined list of hard-coded directories for device drivers, or will accept the path
 # to a single device driver at provided at the VK_ICD_FILENAMES environment variable. So we scan the command line
 # arguments for the swiftshader argument, and only hard-code the path to the swiftshader driver if it is requested.
@@ -30,5 +75,6 @@ else
     CRASHPAD_HANDLER="--crashpadHandlerPath=$HERE/usr/bin/crashpad_handler"
 fi
 
-exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
+$exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
+exit $?
 


### PR DESCRIPTION
## Purpose and motivation

Work-in-progress on #124.

## Implementation

Adopts the AppRun script from https://github.com/darealshinji/AppImageKit-checkrt/blob/master/AppRun.sh. Configures Travis to copy the needed libraries into `install-ext/lib`, which now serves as a signal to the CMake install code to copy them into the `/usr/optional` directory inside of the AppDir.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
