### PR TITLE
fix AppRun based on vanilla Xenial testing

### DIFF
--- a/.travis/before-install-linux.sh
+++ b/.travis/before-install-linux.sh
@@ -78,5 +78,6 @@ else
 
     # signal the installer to include libstdc++ as optional, to support older Linuxes
     cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $TRAVIS_BUILD_DIR/build/install-ext/lib
+    cp /usr/lib/gcc/x86_64-linux-gnu/7/libgcc_s.so.1 $TRAVIS_BUILD_DIR/build/install-ext/lib
 fi
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -581,7 +581,6 @@ elseif(UNIX)
         )
         file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/share/vulkan/explicit_layer.d)
         file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/share/vulkan/icd.d)
-        file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/optional)
     "
     VERBATIM
     )
@@ -597,9 +596,19 @@ elseif(UNIX)
     # of these libraries for compatibility on older version of Linux, and is usually only done on official builds for
     # distribution.
     if (EXISTS "${SCIN_EXT_INSTALL_DIR}/lib/libstdc++.so.6")
-        message(STATUS "including libstdc++.so.6 in the AppImage install")
+        message(STATUS "including local stdc++ libraries in the AppImage install")
+        install(CODE "
+            file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/optional)
+            file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/optional/libstdc++)
+            file(MAKE_DIRECTORY ${SCIN_APPDIR}/usr/optional/libgcc)
+        "
+        VERBATIM
+        )
         install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/libstdc++.so.6"
-            DESTINATION "${SCIN_APPDIR}/usr/optional"
+            DESTINATION "${SCIN_APPDIR}/usr/optional/libstdc++"
+        )
+        install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/libgcc_s.so.1"
+            DESTINATION "${SCIN_APPDIR}/usr/optional/libgcc"
         )
         install(FILES "${SCIN_EXT_INSTALL_DIR}/lib/exec.so"
             DESTINATION "${SCIN_APPDIR}/usr/optional"

--- a/src/linux/AppRun
+++ b/src/linux/AppRun
@@ -20,7 +20,7 @@ if [ -n "$APPIMAGE" ] && [ "$(file -b "$APPIMAGE" | cut -d, -f2)" != " x86-64" ]
   libc6arch="libc6"
 fi
 
-cd "usr"
+cd usr
 
 if [ -e "./optional/libstdc++/libstdc++.so.6" ]; then
   lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libstdc++\.so\.6 ($libc6arch)" | awk 'NR==1{print $NF}')"
@@ -75,6 +75,6 @@ else
     CRASHPAD_HANDLER="--crashpadHandlerPath=$HERE/usr/bin/crashpad_handler"
 fi
 
-$exec "$HERE/usr/bin/scinsynth" $CRASHPAD_HANDLER "$@"
+$exec $CRASHPAD_HANDLER $*
 exit $?
 


### PR DESCRIPTION
## Purpose and motivation

More work on #124. Testing the AppImage on a stock Xenial virtual machine revealed some bugs in the previous work in #167. This hopefully corrects those issues.

## Implementation

The libraries were being installed in the wrong path inside the AppImage, so the script did not pick them up.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
