### PR TITLE
Build fixes for MacOS Big Sur

### DIFF
--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -2,9 +2,10 @@
 
 export HOMEBREW_NO_ANALYTICS=1
 
-brew update
+# brew update
 brew unlink python@2
 brew install ccache doxygen shtool imagemagick gperf
+python3 -m pip install --upgrade pip
 python3 -m pip install pyyaml
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache

--- a/.travis/before-install-osx.sh
+++ b/.travis/before-install-osx.sh
@@ -5,8 +5,8 @@ export HOMEBREW_NO_ANALYTICS=1
 # brew update
 brew unlink python@2
 brew install ccache doxygen shtool imagemagick gperf
-python3 -m pip install --upgrade pip
-python3 -m pip install pyyaml
+# python3 -m pip install --upgrade pip
+python3 -m pip install --user pyyaml
 
 # according to https://docs.travis-ci.com/user/caching#ccache-cache
 export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/.travis/before-install-windows.sh
+++ b/.travis/before-install-windows.sh
@@ -5,7 +5,7 @@ echo "*** installing pyyaml"
 cd $HOME
 git clone https://github.com/yaml/pyyaml.git pyyaml
 cd pyyaml
-/c/Python38/python.exe setup.py install
+/c/Python39/python.exe setup.py install
 
 echo "*** installing Vulkan SDK"
 cd $HOME
@@ -14,6 +14,6 @@ powershell "./vulkan-sdk.exe /S"
 
 echo "*** installing build binary deps"
 cd $TRAVIS_BUILD_DIR
-/c/Python38/python.exe tools/fetch-binary-deps.py
-/c/Python38/python.exe tools/fetch-sclang.py $TRAVIS_HOME/sclang
+/c/Python39/python.exe tools/fetch-binary-deps.py
+/c/Python39/python.exe tools/fetch-sclang.py $TRAVIS_HOME/sclang
 

--- a/.travis/before-script-windows.sh
+++ b/.travis/before-script-windows.sh
@@ -4,6 +4,6 @@ touch $TRAVIS_BUILD_DIR/bin/disable_auto_install
 cd $TRAVIS_BUILD_DIR/build
 cmake -DSCIN_BUILD_DOCS=OFF                                                                                            \
       -DSCIN_SCLANG=$TRAVIS_HOME/sclang/SuperCollider/sclang.exe                                                       \
-      -DPYTHON_EXECUTABLE=/c/Python38/python.exe                                                                       \
+      -DPYTHON_EXECUTABLE=/c/Python39/python.exe                                                                       \
       -DCMAKE_GENERATOR_PLATFORM=x64                                                                                   \
       ..

--- a/src/base/Intrinsic.cpp.in
+++ b/src/base/Intrinsic.cpp.in
@@ -12,6 +12,7 @@
 #elif __GNUC__ || __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wregister"
 #endif
 
 namespace {

--- a/src/comp/RootNode.cpp
+++ b/src/comp/RootNode.cpp
@@ -545,7 +545,7 @@ void RootNode::rebuildCommandBuffer(std::shared_ptr<FrameContext> context) {
             }
 
             std::vector<VkCommandBuffer> commandBuffers;
-            for (const auto command : context->computeCommands()) {
+            for (const auto& command : context->computeCommands()) {
                 commandBuffers.emplace_back(command->buffer(i));
             }
             vkCmdExecuteCommands(m_computePrimary->buffer(i), static_cast<uint32_t>(commandBuffers.size()),
@@ -599,7 +599,7 @@ void RootNode::rebuildCommandBuffer(std::shared_ptr<FrameContext> context) {
                                  VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
             std::vector<VkCommandBuffer> commandBuffers;
-            for (const auto command : context->drawCommands()) {
+            for (const auto& command : context->drawCommands()) {
                 commandBuffers.emplace_back(command->buffer(i));
             }
             vkCmdExecuteCommands(m_drawPrimary->buffer(i), static_cast<uint32_t>(commandBuffers.size()),

--- a/src/comp/Scinth.cpp
+++ b/src/comp/Scinth.cpp
@@ -241,7 +241,7 @@ bool Scinth::allocateDescriptors() {
         std::vector<VkDescriptorImageInfo> imageInfos(totalSamplers);
         auto samplerIndex = 0;
         auto imageInfoIndex = 0;
-        for (const auto pair : m_scinthDef->abstract()->drawFixedImages()) {
+        for (const auto& pair : m_scinthDef->abstract()->drawFixedImages()) {
             std::shared_ptr<vk::DeviceImage> image = m_imageMap->getImage(pair.second);
             if (!image) {
                 spdlog::error("Scinth {} failed to find constant image ID {}.", m_nodeID, pair.second);
@@ -271,7 +271,7 @@ bool Scinth::allocateDescriptors() {
         }
 
         samplerIndex = 0;
-        for (const auto pair : m_scinthDef->abstract()->drawParameterizedImages()) {
+        for (const auto& pair : m_scinthDef->abstract()->drawParameterizedImages()) {
             // Look up default value of parameter using parameter index, provided as second value in the pair.
             size_t parameterIndex = pair.second;
             size_t imageID = static_cast<int>(m_scinthDef->abstract()->parameters()[parameterIndex].defaultValue());

--- a/src/osc/commands/Command.cpp.in
+++ b/src/osc/commands/Command.cpp.in
@@ -11,6 +11,7 @@
 #elif __GNUC__ || __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wregister"
 #endif
 
 namespace {


### PR DESCRIPTION
## Purpose and motivation

Scintillator does not build using the version of Xcode that ships with MacOS Big Sur. This fixes that.

## Implementation

Fix compiler errors until it compiles and runs.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
