### PR TITLE
fix portaudio support on Big Sur

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	url = https://github.com/fmtlib/fmt.git
 [submodule "third_party/portaudio"]
 	path = third_party/portaudio
-	url = https://git.assembla.com/portaudio.git
+	url = https://github.com/PortAudio/portaudio
 [submodule "third_party/tweeny"]
 	path = third_party/tweeny
 	url = https://github.com/mobius3/tweeny


### PR DESCRIPTION
## Purpose and motivation

Fixes #178. Some changes to macOS in Big Sur seem to have broken the older version of portaudio Scintillator was building against. This newer version seems to work fine.

## Implementation

Updated portaudio version.

## Types of changes

* Bug fix

## Status

- [x] This PR is ready for review
